### PR TITLE
#13 / 한판승부생성 뷰 구현

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -101,5 +101,11 @@
             android:exported="false"
             android:screenOrientation="portrait" />
 
+        <activity
+            android:name=".presentation.shortgame.CreateShortGameActivity"
+            android:exported="false"
+            android:screenOrientation="portrait"
+            android:windowSoftInputMode="adjustResize" />
+
     </application>
 </manifest>

--- a/app/src/main/java/sopt/uni/data/entity/shortgame/Mission.kt
+++ b/app/src/main/java/sopt/uni/data/entity/shortgame/Mission.kt
@@ -1,0 +1,7 @@
+package sopt.uni.data.entity.shortgame
+
+data class Mission(
+    val id: Int,
+    val title: String,
+    val image: String
+)

--- a/app/src/main/java/sopt/uni/presentation/entity/MissionIdPosition.kt
+++ b/app/src/main/java/sopt/uni/presentation/entity/MissionIdPosition.kt
@@ -1,0 +1,6 @@
+package sopt.uni.presentation.entity
+
+data class MissionIdPosition(
+    val id: Int,
+    val position: Int
+)

--- a/app/src/main/java/sopt/uni/presentation/shortgame/CreateShortGameActivity.kt
+++ b/app/src/main/java/sopt/uni/presentation/shortgame/CreateShortGameActivity.kt
@@ -24,7 +24,7 @@ class CreateShortGameActivity :
     private val missionAdapter by lazy {
         MissionCategoryAdapter(
             goToMissionDetailClickListener = { missionIdPosition ->
-                //TODO : 미션상세뷰 이동
+                // TODO : 미션상세뷰 이동
             },
             selectMissionClickListener = { missionIdPosition ->
                 selectItem(missionIdPosition.id, missionIdPosition.position)
@@ -69,10 +69,10 @@ class CreateShortGameActivity :
     private fun setClickListener() {
         binding.apply {
             ivClose.setOnClickListener {
-                //TODO : 종료 다이얼로그
+                // TODO : 종료 다이얼로그
             }
             btnCreate.setOnClickListener {
-                //TODO : 생성 다이얼로그 + 미션 기록 액티비티 이동
+                // TODO : 생성 다이얼로그 + 미션 기록 액티비티 이동
             }
         }
     }
@@ -107,4 +107,3 @@ class CreateShortGameActivity :
         }
     }
 }
-

--- a/app/src/main/java/sopt/uni/presentation/shortgame/CreateShortGameActivity.kt
+++ b/app/src/main/java/sopt/uni/presentation/shortgame/CreateShortGameActivity.kt
@@ -1,0 +1,110 @@
+package sopt.uni.presentation.shortgame
+
+import android.content.Context
+import android.graphics.Rect
+import android.os.Bundle
+import android.view.MotionEvent
+import android.view.inputmethod.InputMethodManager
+import android.widget.EditText
+import android.widget.TextView
+import androidx.activity.viewModels
+import androidx.databinding.BindingAdapter
+import dagger.hilt.android.AndroidEntryPoint
+import sopt.uni.R
+import sopt.uni.databinding.ActivityCreateShortGameBinding
+import sopt.uni.util.ItemDecorations
+import sopt.uni.util.binding.BindingActivity
+
+@AndroidEntryPoint
+class CreateShortGameActivity :
+    BindingActivity<ActivityCreateShortGameBinding>(R.layout.activity_create_short_game) {
+
+    private val viewModel: CreateShortGameViewModel by viewModels()
+
+    private val missionAdapter by lazy {
+        MissionCategoryAdapter(
+            goToMissionDetailClickListener = { missionIdPosition ->
+                //TODO : 미션상세뷰 이동
+            },
+            selectMissionClickListener = { missionIdPosition ->
+                selectItem(missionIdPosition.id, missionIdPosition.position)
+            }
+        )
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(binding.root)
+        binding.viewModel = viewModel
+        setAdapter()
+        setClickListener()
+    }
+
+    // 화면 클릭하여 키보드 숨기기 및 포커스 제거
+    override fun dispatchTouchEvent(event: MotionEvent?): Boolean {
+        if (event?.action === MotionEvent.ACTION_DOWN) {
+            val v = currentFocus
+            if (v is EditText) {
+                val outRect = Rect()
+                v.getGlobalVisibleRect(outRect)
+                if (!outRect.contains(event.rawX.toInt(), event.rawY.toInt())) {
+                    v.clearFocus()
+                    val imm: InputMethodManager =
+                        getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+                    imm.hideSoftInputFromWindow(v.getWindowToken(), 0)
+                }
+            }
+        }
+        return super.dispatchTouchEvent(event)
+    }
+
+    private fun setAdapter() {
+        binding.rvMission.adapter = missionAdapter
+        binding.rvMission.addItemDecoration(ItemDecorations(0, 9, 0, 9))
+        viewModel.missionList.observe(this) {
+            missionAdapter.submitList(it)
+        }
+    }
+
+    private fun setClickListener() {
+        binding.apply {
+            ivClose.setOnClickListener {
+                //TODO : 종료 다이얼로그
+            }
+            btnCreate.setOnClickListener {
+                //TODO : 생성 다이얼로그 + 미션 기록 액티비티 이동
+            }
+        }
+    }
+
+    private fun selectItem(id: Int, position: Int) {
+        missionAdapter.setSelectedItem(position)
+        viewModel.setSelectedMissionId(id)
+    }
+
+    companion object {
+        private const val MAX_LENGTH = 54
+
+        @JvmStatic
+        @BindingAdapter("setContentLength")
+        fun setContentLength(view: TextView, length: Int) {
+            if (length >= MAX_LENGTH) {
+                view.setTextColor(view.context.getColor(R.color.Red_500))
+            } else {
+                view.setTextColor(view.context.getColor(R.color.Gray_200))
+            }
+            view.text = "$length/$MAX_LENGTH"
+        }
+
+        @JvmStatic
+        @BindingAdapter("setContentLength")
+        fun setWishContent(view: EditText, length: Int) {
+            if (length >= MAX_LENGTH && view.isFocused) {
+                view.background = view.context.getDrawable(R.drawable.bg_wish_edit_text_error)
+            } else {
+                view.background = view.context.getDrawable(R.drawable.bg_wish_edit_text)
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/sopt/uni/presentation/shortgame/CreateShortGameActivity.kt
+++ b/app/src/main/java/sopt/uni/presentation/shortgame/CreateShortGameActivity.kt
@@ -14,6 +14,7 @@ import sopt.uni.R
 import sopt.uni.databinding.ActivityCreateShortGameBinding
 import sopt.uni.util.ItemDecorations
 import sopt.uni.util.binding.BindingActivity
+import sopt.uni.util.extension.setOnSingleClickListener
 
 @AndroidEntryPoint
 class CreateShortGameActivity :
@@ -68,10 +69,10 @@ class CreateShortGameActivity :
 
     private fun setClickListener() {
         binding.apply {
-            ivClose.setOnClickListener {
+            ivClose.setOnSingleClickListener {
                 // TODO : 종료 다이얼로그
             }
-            btnCreate.setOnClickListener {
+            btnCreate.setOnSingleClickListener {
                 // TODO : 생성 다이얼로그 + 미션 기록 액티비티 이동
             }
         }

--- a/app/src/main/java/sopt/uni/presentation/shortgame/CreateShortGameViewModel.kt
+++ b/app/src/main/java/sopt/uni/presentation/shortgame/CreateShortGameViewModel.kt
@@ -1,0 +1,43 @@
+package sopt.uni.presentation.shortgame
+
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.map
+import sopt.uni.data.entity.shortgame.Mission
+
+class CreateShortGameViewModel : ViewModel() {
+    private val _selectedMissionId = MutableLiveData<Int>()
+    val selectedMissionId = _selectedMissionId
+
+    private val _missionList = MutableLiveData<List<Mission>>()
+    val missionList = _missionList
+
+    val wishContent = MutableLiveData<String>("")
+
+    val contentLength = wishContent.map {
+        it.length
+    }
+
+    init {
+        setDummyList()
+    }
+
+    private fun setDummyList() {
+        val missionList = mutableListOf<Mission>()
+
+        for (i in 0..7) {
+            missionList.add(
+                Mission(
+                    image = "https://github.com/U-is-Ni-in-Korea/Android-United/assets/50603273/8c345eb3-d688-42bd-8585-a02f1016e213",
+                    title = "뀨$i",
+                    id = i,
+                )
+            )
+        }
+        _missionList.value = missionList
+    }
+
+    fun setSelectedMissionId(missionId: Int) {
+        _selectedMissionId.value = missionId
+    }
+}

--- a/app/src/main/java/sopt/uni/presentation/shortgame/MissionCategoryAdapter.kt
+++ b/app/src/main/java/sopt/uni/presentation/shortgame/MissionCategoryAdapter.kt
@@ -17,7 +17,7 @@ class MissionCategoryAdapter(
         onItemsTheSame = { old, new -> old == new },
     ),
 ) {
-    private var selectedPosition = 0;
+    private var selectedPosition = 0
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MissionViewHolder {
         val binding =
             ItemMissionBinding.inflate(LayoutInflater.from(parent.context), parent, false)

--- a/app/src/main/java/sopt/uni/presentation/shortgame/MissionCategoryAdapter.kt
+++ b/app/src/main/java/sopt/uni/presentation/shortgame/MissionCategoryAdapter.kt
@@ -1,0 +1,43 @@
+package sopt.uni.presentation.shortgame
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.ListAdapter
+import sopt.uni.data.entity.shortgame.Mission
+import sopt.uni.databinding.ItemMissionBinding
+import sopt.uni.presentation.entity.MissionIdPosition
+import sopt.uni.util.extension.ItemDiffCallback
+
+class MissionCategoryAdapter(
+    private val goToMissionDetailClickListener: (MissionIdPosition) -> Unit,
+    private val selectMissionClickListener: (MissionIdPosition) -> Unit
+) : ListAdapter<Mission, MissionViewHolder>(
+    ItemDiffCallback<Mission>(
+        onContentsTheSame = { old, new -> old == new },
+        onItemsTheSame = { old, new -> old == new },
+    ),
+) {
+    private var selectedPosition = 0;
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MissionViewHolder {
+        val binding =
+            ItemMissionBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return MissionViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: MissionViewHolder, position: Int) {
+        holder.onBind(
+            getItem(position),
+            position == selectedPosition,
+            position,
+            goToMissionDetailClickListener,
+            selectMissionClickListener
+        )
+    }
+
+    fun setSelectedItem(position: Int) {
+        val prevPosition = selectedPosition
+        selectedPosition = position
+        notifyItemChanged(prevPosition)
+        notifyItemChanged(selectedPosition)
+    }
+}

--- a/app/src/main/java/sopt/uni/presentation/shortgame/MissionViewHolder.kt
+++ b/app/src/main/java/sopt/uni/presentation/shortgame/MissionViewHolder.kt
@@ -1,0 +1,37 @@
+package sopt.uni.presentation.shortgame
+
+import androidx.recyclerview.widget.RecyclerView
+import coil.load
+import sopt.uni.R
+import sopt.uni.data.entity.shortgame.Mission
+import sopt.uni.databinding.ItemMissionBinding
+import sopt.uni.presentation.entity.MissionIdPosition
+
+class MissionViewHolder(val binding: ItemMissionBinding) :
+    RecyclerView.ViewHolder(binding.root) {
+
+    fun onBind(
+        data: Mission,
+        isSelected: Boolean,
+        position: Int,
+        goToMissionDetailClickListener: (MissionIdPosition) -> Unit,
+        selectMissionClickListener: (MissionIdPosition) -> Unit
+    ) {
+
+        binding.apply {
+            ivMission.load(data.image)
+            tvMissionTitle.text = data.title
+            ivMissionDetail.setOnClickListener {
+                goToMissionDetailClickListener(MissionIdPosition(data.id, position))
+            }
+            root.setOnClickListener {
+                selectMissionClickListener(MissionIdPosition(data.id, position))
+            }
+        }
+
+        if (isSelected)
+            binding.cvBackground.setBackgroundResource(R.drawable.bg_mission_hover)
+        else
+            binding.cvBackground.setBackgroundResource(0)
+    }
+}

--- a/app/src/main/java/sopt/uni/util/ItemDecorations.kt
+++ b/app/src/main/java/sopt/uni/util/ItemDecorations.kt
@@ -1,0 +1,33 @@
+package sopt.uni.util
+
+import android.content.res.Resources
+import android.graphics.Rect
+import android.view.View
+import androidx.recyclerview.widget.RecyclerView
+import kotlin.math.roundToInt
+
+class ItemDecorations(
+    private val topSpace: Int,
+    private val bottomSpace: Int,
+    private val leftSpace: Int,
+    private val rightSpace: Int
+) : RecyclerView.ItemDecoration() {
+    override fun getItemOffsets(
+        outRect: Rect,
+        view: View,
+        parent: RecyclerView,
+        state: RecyclerView.State
+    ) {
+        super.getItemOffsets(outRect, view, parent, state)
+
+        outRect.top = dpToPx(topSpace)
+        outRect.bottom = dpToPx(bottomSpace)
+        outRect.left = dpToPx(leftSpace)
+        outRect.right = dpToPx(rightSpace)
+    }
+
+    private fun dpToPx(dp: Int): Int {
+        val density = Resources.getSystem().displayMetrics.density
+        return (dp * density).roundToInt()
+    }
+}

--- a/app/src/main/res/drawable/bg_mission_hover.xml
+++ b/app/src/main/res/drawable/bg_mission_hover.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <stroke
+        android:width="1dp"
+        android:color="@color/Lightblue_500" />
+    <corners
+        android:radius="10dp"/>
+</shape>

--- a/app/src/main/res/drawable/bg_shortgame_btn.xml
+++ b/app/src/main/res/drawable/bg_shortgame_btn.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/Lightblue_500" />
+    <corners android:radius="10dp"/>
+</shape>

--- a/app/src/main/res/drawable/bg_wish_edit_text.xml
+++ b/app/src/main/res/drawable/bg_wish_edit_text.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_focused="true">
+        <shape android:shape="rectangle">
+            <stroke android:width="1dp" android:color="@color/Lightblue_500" />
+            <corners android:radius="6dp" />
+            <solid android:color="@color/Gray_100"/>
+        </shape>
+    </item>
+
+    <item android:state_focused="false">
+        <shape android:shape="rectangle">
+            <corners android:radius="6dp" />
+            <solid android:color="@color/Gray_100"/>
+        </shape>
+    </item>
+
+</selector>

--- a/app/src/main/res/drawable/bg_wish_edit_text_error.xml
+++ b/app/src/main/res/drawable/bg_wish_edit_text_error.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <stroke android:color="@color/Red_500" android:width="2dp" />
+    <corners android:radius="6dp" />
+    <solid android:color="@color/Gray_100"/>
+</shape>

--- a/app/src/main/res/drawable/ic_wish_ticket.xml
+++ b/app/src/main/res/drawable/ic_wish_ticket.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="328dp"
+    android:height="112dp"
+    android:viewportWidth="328"
+    android:viewportHeight="112">
+  <path
+      android:pathData="M6,0C2.69,0 0,2.69 0,6V46C5.52,46 10,50.48 10,56C10,61.52 5.52,66 0,66V106C0,109.31 2.69,112 6,112H273V106.82H277V112H322C325.31,112 328,109.31 328,106V66C322.48,66 318,61.52 318,56C318,50.48 322.48,46 328,46V6C328,2.69 325.31,0 322,0H277V5.19H273V0H6ZM273,13.48V23.85H277V13.48H273ZM273,32.15V42.52H277V32.15H273ZM273,50.81V61.19H277V50.81H273ZM273,69.48V79.85H277V69.48H273ZM273,88.15V98.52H277V88.15H273Z"
+      android:fillColor="#ffffff"
+      android:fillType="evenOdd"/>
+</vector>

--- a/app/src/main/res/layout/activity_create_short_game.xml
+++ b/app/src/main/res/layout/activity_create_short_game.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="viewModel"
+            type="sopt.uni.presentation.shortgame.CreateShortGameViewModel" />
+    </data>
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/cl_create_short_game_bg"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="@color/Gray_100"
+            tools:context=".presentation.shortgame.CreateShortGameActivity">
+
+            <TextView
+                android:id="@+id/tv_title"
+                style="@style/Subtitle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginVertical="14dp"
+                android:layout_marginStart="16dp"
+                android:text="@string/create_short_game_title"
+                android:textColor="@color/Gray_600"
+                app:layout_constraintBottom_toTopOf="@+id/tv_select_category"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <ImageView
+                android:id="@+id/iv_close"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="5dp"
+                android:src="@drawable/ic_dismiss"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="@id/tv_title" />
+
+            <TextView
+                android:id="@+id/tv_select_category"
+                style="@style/Subtitle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="16dp"
+                android:text="@string/create_short_game_select_mission"
+                android:textColor="@color/Gray_600"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/tv_title" />
+
+            <TextView
+                android:id="@+id/tv_script"
+                style="@style/Body2"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="6dp"
+                android:text="@string/create_short_game_more_script"
+                android:textColor="@color/Gray_350"
+                app:layout_constraintBottom_toTopOf="@id/rv_mission"
+                app:layout_constraintLeft_toLeftOf="@id/tv_select_category"
+                app:layout_constraintTop_toBottomOf="@id/tv_select_category" />
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rv_mission"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="11dp"
+                android:layout_marginBottom="11dp"
+                android:clipToPadding="false"
+                android:orientation="vertical"
+                app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
+                app:layout_constraintTop_toBottomOf="@id/tv_script"
+                app:spanCount="2"
+                tools:listitem="@layout/item_mission">
+
+            </androidx.recyclerview.widget.RecyclerView>
+
+            <TextView
+                android:id="@+id/tv_wish"
+                style="@style/Subtitle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_margin="16dp"
+                android:text="@string/create_short_game_wish"
+                android:textColor="@color/Gray_600"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/rv_mission" />
+
+            <ImageView
+                android:id="@+id/iv_ticket"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="16dp"
+                android:layout_marginTop="16dp"
+                android:adjustViewBounds="true"
+                android:src="@drawable/ic_wish_ticket"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/tv_wish" />
+
+            <EditText
+                android:id="@+id/et_wish_content"
+                style="@style/Body2"
+                setContentLength="@{viewModel.contentLength}"
+                android:layout_width="238dp"
+                android:layout_height="90dp"
+                android:layout_marginStart="19dp"
+                android:background="@drawable/bg_wish_edit_text"
+                android:gravity="top"
+                android:hint="@string/create_short_game_wish_content_hint"
+                android:importantForAutofill="no"
+                android:inputType="textMultiLine"
+                android:maxLength="54"
+                android:maxLines="3"
+                android:padding="10dp"
+                android:text="@={viewModel.wishContent}"
+                app:layout_constraintBottom_toBottomOf="@id/iv_ticket"
+                app:layout_constraintStart_toStartOf="@id/iv_ticket"
+                app:layout_constraintTop_toTopOf="@id/iv_ticket" />
+
+            <TextView
+                android:id="@+id/tv_content_length"
+                style="@style/Caption"
+                setContentLength="@{viewModel.contentLength}"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="12dp"
+                android:layout_marginBottom="16dp"
+                android:textColor="@color/Gray_200"
+                app:layout_constraintBottom_toBottomOf="@id/iv_ticket"
+                app:layout_constraintEnd_toEndOf="@id/iv_ticket"
+                tools:text="0/54" />
+
+
+            <androidx.appcompat.widget.AppCompatButton
+                android:id="@+id/btn_create"
+                style="@style/Btn1"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="20dp"
+                android:layout_marginVertical="16dp"
+                android:layout_marginBottom="56dp"
+                android:background="@drawable/bg_shortgame_btn"
+                android:text="@string/create_short_game_btn"
+                android:textColor="@color/Gray_000"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/iv_ticket">
+
+            </androidx.appcompat.widget.AppCompatButton>
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </ScrollView>
+</layout>

--- a/app/src/main/res/layout/item_mission.xml
+++ b/app/src/main/res/layout/item_mission.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+
+        <variable
+            name="mission"
+            type="sopt.uni.data.entity.shortgame.Mission" />
+    </data>
+
+    <androidx.cardview.widget.CardView
+        android:id="@+id/cv_background"
+        android:layout_width="match_parent"
+        android:layout_height="78dp"
+        app:cardBackgroundColor="@color/Gray_000"
+        app:cardCornerRadius="10dp">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:paddingVertical="12dp"
+            android:paddingStart="12dp">
+
+            <ImageView
+                android:id="@+id/iv_mission"
+                android:layout_width="32dp"
+                android:layout_height="32dp"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/tv_mission_title"
+                style="@style/Btn2"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintLeft_toLeftOf="@id/iv_mission"
+                app:layout_constraintTop_toBottomOf="@id/iv_mission" />
+
+            <ImageView
+                android:id="@+id/iv_mission_detail"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:layout_marginEnd="6dp"
+                android:src="@drawable/ic_chevron_right_24"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintRight_toRightOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.cardview.widget.CardView>
+</layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -76,4 +76,13 @@
     <string name="kakao_login">카카오 로그인</string>
     <string name="google_login">Google계정으로 로그인</string>
 
+
+    <!-- createShortGame -->
+    <string name="create_short_game_title">한판승부</string>
+    <string name="create_short_game_select_mission">미션 카테고리 선택하기</string>
+    <string name="create_short_game_more_script">더보기 버튼을 눌러 설명을 볼 수 있어요</string>
+    <string name="create_short_game_wish">소원 정하기</string>
+    <string name="create_short_game_wish_content_hint">이번 승부에 걸 소원을 입력해주세요! \n소원은 지금 정하지 않고 승부가 끝난 뒤에도 작성할 수 있어요</string>
+    <string name="create_short_game_btn">한판 승부 만들기</string>
+
 </resources>


### PR DESCRIPTION
## 📌 관련 이슈
- #13 

## 📷 screenshot
https://github.com/U-is-Ni-in-Korea/Android-United/assets/50603273/c8861d8e-e6e2-4643-91fa-c96ac68b5c3c

## 📝 Work Desciption
- 한판승부 뷰 작업 완료
- 미션 카테고리 선택시 hover모드 및 missionId, position 클릭리스너로 빼는 로직 구현
- EditText 글자 수 제한 및 스타일 적용 로직 구현

## 📚 Reference 혹은 궁금한 사항들
지금 EditText 부분 dp로 박았는데 나중에 비율 계산하도록 하겠습니다 ㅎㅎ
