### PR TITLE
#57 / 한판승부기록 기능 구현

### DIFF
--- a/app/src/main/java/sopt/uni/data/entity/shortgame/RoundMission.kt
+++ b/app/src/main/java/sopt/uni/data/entity/shortgame/RoundMission.kt
@@ -14,5 +14,5 @@ data class RoundMission(
     @SerialName("result")
     val result: String,
     @SerialName("updatedAt")
-    val updatedAt: String,
+    val updatedAt: String?,
 )

--- a/app/src/main/java/sopt/uni/presentation/shortgame/missionrecord/MissionRecordActivity.kt
+++ b/app/src/main/java/sopt/uni/presentation/shortgame/missionrecord/MissionRecordActivity.kt
@@ -7,7 +7,9 @@ import androidx.activity.viewModels
 import dagger.hilt.android.AndroidEntryPoint
 import sopt.uni.R
 import sopt.uni.databinding.ActivityMissionRecordBinding
+import sopt.uni.presentation.shortgame.createshortgame.dialog.CreateShortGameDialogFragment
 import sopt.uni.presentation.shortgame.missiondetailrecord.MissionDetailRecordActivity
+import sopt.uni.presentation.shortgame.missionresult.MissionResultActivity
 import sopt.uni.util.binding.BindingActivity
 import sopt.uni.util.extension.setOnSingleClickListener
 
@@ -22,12 +24,41 @@ class MissionRecordActivity :
         setContentView(binding.root)
         binding.missionRecordViewModel = viewModel
         setClickListener()
+        setViewModelObserve()
+    }
+
+    private fun cancelDialog() {
+        CreateShortGameDialogFragment().apply {
+            titleText = this@MissionRecordActivity.resources.getString(R.string.mission_detatil_record_rule_title)
+            bodyText = this@MissionRecordActivity.resources.getString(R.string.mission_record_cancel_dialog_body)
+            confirmButtonText = this@MissionRecordActivity.resources.getString(R.string.dialog_ok_text)
+            dismissButtonText = this@MissionRecordActivity.resources.getString(R.string.dialog_cancel_text)
+            confirmClickListener = {
+                viewModel.requestStopMission()
+                this.dismiss()
+            }
+            dismissClickListener = {
+                this.dismiss()
+            }
+        }.show(supportFragmentManager, "")
+    }
+
+    private fun setViewModelObserve() {
+        viewModel.isMissionCancelSuccess.observe(this) {
+            if (it) finish()
+        }
+        viewModel.isMissionRequestSuccess.observe(this) {
+            if (it) {
+                MissionResultActivity.start(this, viewModel.roundGameId)
+                finish()
+            }
+        }
     }
 
     private fun setClickListener() {
         binding.apply {
             tvStopGame.setOnSingleClickListener {
-                // TODO : 승부 그만두기 다이얼로그
+                cancelDialog()
             }
             ivMissionDetail.setOnSingleClickListener {
                 MissionDetailRecordActivity.start(

--- a/app/src/main/java/sopt/uni/presentation/shortgame/missionrecord/MissionRecordViewModel.kt
+++ b/app/src/main/java/sopt/uni/presentation/shortgame/missionrecord/MissionRecordViewModel.kt
@@ -1,25 +1,36 @@
 package sopt.uni.presentation.shortgame.missionrecord
 
+import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.map
+import sopt.uni.data.entity.shortgame.ResponseShortGameResult
 
 class MissionRecordViewModel(private val savedStateHandle: SavedStateHandle) : ViewModel() {
     val roundGameId: Int = savedStateHandle.get<Int>(MissionRecordActivity.ROUND_GAME_ID) ?: -1
-    val missionId = MutableLiveData<Int>(1)
-    val missionImage = MutableLiveData<String>("")
-    val missionContent = MutableLiveData<String>("헤드셋")
-    val missionTitle = MutableLiveData<String>("키워드 스무고개")
+
+    private val _missionResult = MutableLiveData<ResponseShortGameResult>()
+    val missionResult: LiveData<ResponseShortGameResult> = _missionResult
+
+    private val _isMissionCancelSuccess = MutableLiveData<Boolean>(false)
+    val isMissionCancelSuccess = _isMissionCancelSuccess
+
+    private val _isMissionRequestSuccess = MutableLiveData<Boolean>(false)
+    val isMissionRequestSuccess = _isMissionRequestSuccess
+
+    val myMissionResult = missionResult.map { it.myRoundMission }
+    val missionId = myMissionResult.map { it.missionContent.id }
 
     fun loadMissionRecord() {
         // TODO: Get 승부기록뷰 정보
     }
 
     fun requestMission(missionRequest: Boolean) {
-        // TODO: 미션완료,실패 API 호출
+        _isMissionRequestSuccess.postValue(true)
     }
 
     fun requestStopMission() {
-        // TODO: 승부그만두기 API 호출
+        _isMissionCancelSuccess.postValue(true)
     }
 }

--- a/app/src/main/java/sopt/uni/presentation/shortgame/missionresult/MissionResultActivity.kt
+++ b/app/src/main/java/sopt/uni/presentation/shortgame/missionresult/MissionResultActivity.kt
@@ -10,6 +10,7 @@ import androidx.databinding.BindingAdapter
 import sopt.uni.R
 import sopt.uni.data.entity.shortgame.MissionResultState
 import sopt.uni.databinding.ActivityMissionResultBinding
+import sopt.uni.presentation.shortgame.missionrecord.MissionRecordActivity
 import sopt.uni.util.binding.BindingActivity
 import sopt.uni.util.extension.setOnSingleClickListener
 
@@ -73,7 +74,6 @@ class MissionResultActivity :
     }
 
     companion object {
-        const val ROUND_GAME_ID = "ROUND_GAME_ID"
 
         fun start(context: Context, roundGameId: Int) {
             context.startActivity(getIntent(context, roundGameId))
@@ -81,7 +81,7 @@ class MissionResultActivity :
 
         private fun getIntent(context: Context, roundGameId: Int) =
             Intent(context, MissionResultActivity::class.java).putExtra(
-                ROUND_GAME_ID,
+                MissionRecordActivity.ROUND_GAME_ID,
                 roundGameId,
             )
 

--- a/app/src/main/res/layout/activity_mission_record.xml
+++ b/app/src/main/res/layout/activity_mission_record.xml
@@ -65,10 +65,10 @@
 
             <ImageView
                 android:id="@+id/iv_mission"
+                setImage="@{missionRecordViewModel.myMissionResult.missionContent.missionCategory.image}"
                 android:layout_width="77dp"
                 android:layout_height="77dp"
                 android:background="@drawable/bg_mission_image_round"
-                android:src="@drawable/imagecard_android"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
@@ -79,7 +79,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="20dp"
                 android:layout_marginTop="16dp"
-                android:text="@{missionRecordViewModel.missionContent}"
+                android:text="@{missionRecordViewModel.myMissionResult.missionContent.content}"
                 android:textColor="@color/Gray_600"
                 android:textFontWeight="600"
                 app:layout_constraintStart_toEndOf="@id/iv_mission"
@@ -93,7 +93,7 @@
                 android:layout_marginStart="20dp"
                 android:layout_marginTop="6dp"
                 android:fontFamily="@font/pretendard"
-                android:text="@{missionRecordViewModel.missionTitle}"
+                android:text="@{missionRecordViewModel.myMissionResult.missionContent.missionCategory.title}"
                 android:textColor="@color/Gray_600"
                 android:textFontWeight="400"
                 android:textSize="14dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -172,5 +172,10 @@
     <string name="create_short_game_create_dialog_title">설정된 내용으로 승부를 만들까요?</string>
     <string name="create_short_game_create_dialog_body">한번 설정한 내용은 변경할 수 없어요</string>
     <string name="create_short_game_create_dialog_create">만들기</string>
+
+
+    <!-- MissionRecord dialog -->
+    <string name="mission_record_cancel_dialog_title">승부를 이대로 중단하시나요?</string>
+    <string name="mission_record_cancel_dialog_body">소모된 하트는 다시 돌아오지 않아요</string>
     
 </resources>


### PR DESCRIPTION
## 📌 관련 이슈
close #57 

## 📷 screenshot
음슴

## 📝 Work Desciption
- 한판승부기록 화면전환 기능 구현
- 한판승부기록 승부그만두기 다이얼로그 기능 구현
- 한판승부기록 미션성공,실패 기능 구현(api만 붙이면 됨)

## 📚 Reference 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
