### PR TITLE
#61 한판승부 API 연동 및 레파지토리 패턴 적용

### DIFF
--- a/app/src/main/java/sopt/uni/data/entity/shortgame/Mission.kt
+++ b/app/src/main/java/sopt/uni/data/entity/shortgame/Mission.kt
@@ -1,3 +1,0 @@
-package sopt.uni.data.entity.shortgame
-
-data class Mission(val id: Int, val title: String, val image: String)

--- a/app/src/main/java/sopt/uni/data/entity/shortgame/MissionDetail.kt
+++ b/app/src/main/java/sopt/uni/data/entity/shortgame/MissionDetail.kt
@@ -1,11 +1,22 @@
 package sopt.uni.data.entity.shortgame
 
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class MissionDetail(
+    @SerialName("id")
     val id: Int,
+    @SerialName("title")
     val title: String,
+    @SerialName("description")
     val description: String,
+    @SerialName("rule")
     val rule: String,
+    @SerialName("tip")
     val tip: String,
+    @SerialName("image")
     val image: String,
-    val missionContentList: List<MissionExample>
+    @SerialName("missionContentList")
+    val missionContentList: List<MissionExample>,
 )

--- a/app/src/main/java/sopt/uni/data/entity/shortgame/MissionExample.kt
+++ b/app/src/main/java/sopt/uni/data/entity/shortgame/MissionExample.kt
@@ -1,3 +1,12 @@
 package sopt.uni.data.entity.shortgame
 
-data class MissionExample(val id: Int, val content: String)
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MissionExample(
+    @SerialName("id")
+    val id: Int,
+    @SerialName("content")
+    val content: String,
+)

--- a/app/src/main/java/sopt/uni/data/entity/shortgame/ShortGame.kt
+++ b/app/src/main/java/sopt/uni/data/entity/shortgame/ShortGame.kt
@@ -1,0 +1,14 @@
+package sopt.uni.data.entity.shortgame
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ShortGame(
+    @SerialName("enable")
+    val enable: Boolean,
+    @SerialName("finishAt")
+    val finishAt: String?,
+    @SerialName("id")
+    val id: Int,
+)

--- a/app/src/main/java/sopt/uni/data/repository/shortgame/ShortGameRepository.kt
+++ b/app/src/main/java/sopt/uni/data/repository/shortgame/ShortGameRepository.kt
@@ -10,4 +10,6 @@ interface ShortGameRepository {
         missionCategoryId: Int,
         wishContent: String,
     ): Result<ResponseCreateShortGameDto>
+
+    suspend fun getMissionDetail(missionCategoryId: Int): Result<MissionDetail>
 }

--- a/app/src/main/java/sopt/uni/data/repository/shortgame/ShortGameRepository.kt
+++ b/app/src/main/java/sopt/uni/data/repository/shortgame/ShortGameRepository.kt
@@ -2,6 +2,7 @@ package sopt.uni.data.repository.shortgame
 
 import sopt.uni.data.entity.shortgame.MissionDetail
 import sopt.uni.data.source.remote.response.ResponseCreateShortGameDto
+import sopt.uni.data.source.remote.response.ResponseShortGameResultDto
 
 interface ShortGameRepository {
     suspend fun getMissionCategory(): Result<List<MissionDetail>>
@@ -12,4 +13,6 @@ interface ShortGameRepository {
     ): Result<ResponseCreateShortGameDto>
 
     suspend fun getMissionDetail(missionCategoryId: Int): Result<MissionDetail>
+
+    suspend fun getShortGameResult(roundGameId: Int): Result<ResponseShortGameResultDto>
 }

--- a/app/src/main/java/sopt/uni/data/repository/shortgame/ShortGameRepository.kt
+++ b/app/src/main/java/sopt/uni/data/repository/shortgame/ShortGameRepository.kt
@@ -20,4 +20,6 @@ interface ShortGameRepository {
         roundGameId: Int,
         result: Boolean,
     ): Result<ResponseShortGameResultDto>
+
+    suspend fun deleteShortGame(roundGameId: Int): Result<Unit>
 }

--- a/app/src/main/java/sopt/uni/data/repository/shortgame/ShortGameRepository.kt
+++ b/app/src/main/java/sopt/uni/data/repository/shortgame/ShortGameRepository.kt
@@ -1,7 +1,13 @@
 package sopt.uni.data.repository.shortgame
 
 import sopt.uni.data.entity.shortgame.MissionDetail
+import sopt.uni.data.source.remote.response.ResponseCreateShortGameDto
 
 interface ShortGameRepository {
     suspend fun getMissionCategory(): Result<List<MissionDetail>>
+
+    suspend fun createShortGame(
+        missionCategoryId: Int,
+        wishContent: String,
+    ): Result<ResponseCreateShortGameDto>
 }

--- a/app/src/main/java/sopt/uni/data/repository/shortgame/ShortGameRepository.kt
+++ b/app/src/main/java/sopt/uni/data/repository/shortgame/ShortGameRepository.kt
@@ -1,0 +1,7 @@
+package sopt.uni.data.repository.shortgame
+
+import sopt.uni.data.entity.shortgame.MissionDetail
+
+interface ShortGameRepository {
+    suspend fun getMissionCategory(): Result<List<MissionDetail>>
+}

--- a/app/src/main/java/sopt/uni/data/repository/shortgame/ShortGameRepository.kt
+++ b/app/src/main/java/sopt/uni/data/repository/shortgame/ShortGameRepository.kt
@@ -15,4 +15,9 @@ interface ShortGameRepository {
     suspend fun getMissionDetail(missionCategoryId: Int): Result<MissionDetail>
 
     suspend fun getShortGameResult(roundGameId: Int): Result<ResponseShortGameResultDto>
+
+    suspend fun recordShortGame(
+        roundGameId: Int,
+        result: Boolean,
+    ): Result<ResponseShortGameResultDto>
 }

--- a/app/src/main/java/sopt/uni/data/repository/shortgame/ShortGameRepositoryImpl.kt
+++ b/app/src/main/java/sopt/uni/data/repository/shortgame/ShortGameRepositoryImpl.kt
@@ -64,4 +64,13 @@ class ShortGameRepositoryImpl @Inject constructor(private val shortGameService: 
         }.onFailure {
             Result.failure<ResponseShortGameResultDto>(it)
         }
+
+    override suspend fun deleteShortGame(roundGameId: Int): Result<Unit> =
+        kotlin.runCatching {
+            shortGameService.deleteShortGameResult(roundGameId)
+        }.onSuccess {
+            Result.success(Unit)
+        }.onFailure {
+            Result.failure<Unit>(it)
+        }
 }

--- a/app/src/main/java/sopt/uni/data/repository/shortgame/ShortGameRepositoryImpl.kt
+++ b/app/src/main/java/sopt/uni/data/repository/shortgame/ShortGameRepositoryImpl.kt
@@ -3,6 +3,7 @@ package sopt.uni.data.repository.shortgame
 import sopt.uni.data.entity.shortgame.MissionDetail
 import sopt.uni.data.service.ShortGameService
 import sopt.uni.data.source.remote.request.RequestCreateShortGameDto
+import sopt.uni.data.source.remote.request.RequestRecordShortGameDto
 import sopt.uni.data.source.remote.response.ResponseCreateShortGameDto
 import sopt.uni.data.source.remote.response.ResponseShortGameResultDto
 import javax.inject.Inject
@@ -40,9 +41,24 @@ class ShortGameRepositoryImpl @Inject constructor(private val shortGameService: 
             Result.failure<MissionDetail>(it)
         }
 
-    override suspend fun getShortGameResult(roundGameId: Int): Result<ResponseShortGameResultDto> =
+    override suspend fun getShortGameResult(
+        roundGameId: Int,
+    ): Result<ResponseShortGameResultDto> =
         kotlin.runCatching {
             shortGameService.getShortGameResult(roundGameId)
+        }.onSuccess {
+            Result.success(it)
+        }.onFailure {
+            Result.failure<ResponseShortGameResultDto>(it)
+        }
+
+    override suspend fun recordShortGame(
+        roundGameId: Int,
+        result: Boolean,
+    ): Result<ResponseShortGameResultDto> =
+        kotlin.runCatching {
+            val requestBody = RequestRecordShortGameDto(result)
+            shortGameService.patchShortGameResult(roundGameId, requestBody)
         }.onSuccess {
             Result.success(it)
         }.onFailure {

--- a/app/src/main/java/sopt/uni/data/repository/shortgame/ShortGameRepositoryImpl.kt
+++ b/app/src/main/java/sopt/uni/data/repository/shortgame/ShortGameRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package sopt.uni.data.repository.shortgame
 
+import retrofit2.Response
 import sopt.uni.data.entity.shortgame.MissionDetail
 import sopt.uni.data.service.ShortGameService
 import sopt.uni.data.source.remote.request.RequestCreateShortGameDto
@@ -67,7 +68,7 @@ class ShortGameRepositoryImpl @Inject constructor(private val shortGameService: 
 
     override suspend fun deleteShortGame(roundGameId: Int): Result<Unit> =
         kotlin.runCatching {
-            shortGameService.deleteShortGameResult(roundGameId)
+            shortGameService.deleteShortGameResult(roundGameId).body() ?: Unit
         }.onSuccess {
             Result.success(Unit)
         }.onFailure {

--- a/app/src/main/java/sopt/uni/data/repository/shortgame/ShortGameRepositoryImpl.kt
+++ b/app/src/main/java/sopt/uni/data/repository/shortgame/ShortGameRepositoryImpl.kt
@@ -1,0 +1,18 @@
+package sopt.uni.data.repository.shortgame
+
+import sopt.uni.data.entity.auth.Token
+import sopt.uni.data.entity.shortgame.MissionDetail
+import sopt.uni.data.service.ShortGameService
+import javax.inject.Inject
+
+class ShortGameRepositoryImpl @Inject constructor(private val shortGameService: ShortGameService) :
+    ShortGameRepository {
+    override suspend fun getMissionCategory(): Result<List<MissionDetail>> =
+        kotlin.runCatching {
+            shortGameService.getMissionCategoryList()
+        }.onSuccess {
+            Result.success(it)
+        }.onFailure {
+            Result.failure<Token>(it)
+        }
+}

--- a/app/src/main/java/sopt/uni/data/repository/shortgame/ShortGameRepositoryImpl.kt
+++ b/app/src/main/java/sopt/uni/data/repository/shortgame/ShortGameRepositoryImpl.kt
@@ -4,6 +4,7 @@ import sopt.uni.data.entity.shortgame.MissionDetail
 import sopt.uni.data.service.ShortGameService
 import sopt.uni.data.source.remote.request.RequestCreateShortGameDto
 import sopt.uni.data.source.remote.response.ResponseCreateShortGameDto
+import sopt.uni.data.source.remote.response.ResponseShortGameResultDto
 import javax.inject.Inject
 
 class ShortGameRepositoryImpl @Inject constructor(private val shortGameService: ShortGameService) :
@@ -37,5 +38,14 @@ class ShortGameRepositoryImpl @Inject constructor(private val shortGameService: 
             Result.success(it)
         }.onFailure {
             Result.failure<MissionDetail>(it)
+        }
+
+    override suspend fun getShortGameResult(roundGameId: Int): Result<ResponseShortGameResultDto> =
+        kotlin.runCatching {
+            shortGameService.getShortGameResult(roundGameId)
+        }.onSuccess {
+            Result.success(it)
+        }.onFailure {
+            Result.failure<ResponseShortGameResultDto>(it)
         }
 }

--- a/app/src/main/java/sopt/uni/data/repository/shortgame/ShortGameRepositoryImpl.kt
+++ b/app/src/main/java/sopt/uni/data/repository/shortgame/ShortGameRepositoryImpl.kt
@@ -1,6 +1,5 @@
 package sopt.uni.data.repository.shortgame
 
-import retrofit2.Response
 import sopt.uni.data.entity.shortgame.MissionDetail
 import sopt.uni.data.service.ShortGameService
 import sopt.uni.data.source.remote.request.RequestCreateShortGameDto

--- a/app/src/main/java/sopt/uni/data/repository/shortgame/ShortGameRepositoryImpl.kt
+++ b/app/src/main/java/sopt/uni/data/repository/shortgame/ShortGameRepositoryImpl.kt
@@ -29,4 +29,13 @@ class ShortGameRepositoryImpl @Inject constructor(private val shortGameService: 
         }.onFailure {
             Result.failure<ResponseCreateShortGameDto>(it)
         }
+
+    override suspend fun getMissionDetail(missionCategoryId: Int): Result<MissionDetail> =
+        kotlin.runCatching {
+            shortGameService.getMissionDetail(missionCategoryId)
+        }.onSuccess {
+            Result.success(it)
+        }.onFailure {
+            Result.failure<MissionDetail>(it)
+        }
 }

--- a/app/src/main/java/sopt/uni/data/repository/shortgame/ShortGameRepositoryImpl.kt
+++ b/app/src/main/java/sopt/uni/data/repository/shortgame/ShortGameRepositoryImpl.kt
@@ -1,8 +1,9 @@
 package sopt.uni.data.repository.shortgame
 
-import sopt.uni.data.entity.auth.Token
 import sopt.uni.data.entity.shortgame.MissionDetail
 import sopt.uni.data.service.ShortGameService
+import sopt.uni.data.source.remote.request.RequestCreateShortGameDto
+import sopt.uni.data.source.remote.response.ResponseCreateShortGameDto
 import javax.inject.Inject
 
 class ShortGameRepositoryImpl @Inject constructor(private val shortGameService: ShortGameService) :
@@ -13,6 +14,19 @@ class ShortGameRepositoryImpl @Inject constructor(private val shortGameService: 
         }.onSuccess {
             Result.success(it)
         }.onFailure {
-            Result.failure<Token>(it)
+            Result.failure<List<MissionDetail>>(it)
+        }
+
+    override suspend fun createShortGame(
+        missionCategoryId: Int,
+        wishContent: String,
+    ): Result<ResponseCreateShortGameDto> =
+        kotlin.runCatching {
+            val requestBody = RequestCreateShortGameDto(missionCategoryId, wishContent)
+            shortGameService.postCreateShortGame(requestBody)
+        }.onSuccess {
+            Result.success(it)
+        }.onFailure {
+            Result.failure<ResponseCreateShortGameDto>(it)
         }
 }

--- a/app/src/main/java/sopt/uni/data/service/ShortGameService.kt
+++ b/app/src/main/java/sopt/uni/data/service/ShortGameService.kt
@@ -1,6 +1,7 @@
 package sopt.uni.data.service
 
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.PATCH
 import retrofit2.http.POST
@@ -35,4 +36,9 @@ interface ShortGameService {
         @Path("roundGameId") roundGameId: Int,
         @Body request: RequestRecordShortGameDto,
     ): ResponseShortGameResultDto
+
+    @DELETE("/api/game/short/{roundGameId}")
+    suspend fun deleteShortGameResult(
+        @Path("roundGameId") roundGameId: Int,
+    )
 }

--- a/app/src/main/java/sopt/uni/data/service/ShortGameService.kt
+++ b/app/src/main/java/sopt/uni/data/service/ShortGameService.kt
@@ -2,10 +2,12 @@ package sopt.uni.data.service
 
 import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.Path
 import sopt.uni.data.entity.shortgame.MissionDetail
 import sopt.uni.data.source.remote.request.RequestCreateShortGameDto
+import sopt.uni.data.source.remote.request.RequestRecordShortGameDto
 import sopt.uni.data.source.remote.response.ResponseCreateShortGameDto
 import sopt.uni.data.source.remote.response.ResponseShortGameResultDto
 
@@ -26,5 +28,11 @@ interface ShortGameService {
     @GET("/api/game/short/{roundGameId}")
     suspend fun getShortGameResult(
         @Path("roundGameId") roundGameId: Int,
+    ): ResponseShortGameResultDto
+
+    @PATCH("/api/game/short/{roundGameId}")
+    suspend fun patchShortGameResult(
+        @Path("roundGameId") roundGameId: Int,
+        @Body request: RequestRecordShortGameDto,
     ): ResponseShortGameResultDto
 }

--- a/app/src/main/java/sopt/uni/data/service/ShortGameService.kt
+++ b/app/src/main/java/sopt/uni/data/service/ShortGameService.kt
@@ -1,0 +1,9 @@
+package sopt.uni.data.service
+
+import retrofit2.http.GET
+import sopt.uni.data.entity.shortgame.MissionDetail
+
+interface ShortGameService {
+    @GET("/api/mission")
+    suspend fun getMissionCategoryList(): List<MissionDetail>
+}

--- a/app/src/main/java/sopt/uni/data/service/ShortGameService.kt
+++ b/app/src/main/java/sopt/uni/data/service/ShortGameService.kt
@@ -1,5 +1,6 @@
 package sopt.uni.data.service
 
+import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
@@ -40,5 +41,5 @@ interface ShortGameService {
     @DELETE("/api/game/short/{roundGameId}")
     suspend fun deleteShortGameResult(
         @Path("roundGameId") roundGameId: Int,
-    )
+    ): Response<Unit>
 }

--- a/app/src/main/java/sopt/uni/data/service/ShortGameService.kt
+++ b/app/src/main/java/sopt/uni/data/service/ShortGameService.kt
@@ -3,6 +3,7 @@ package sopt.uni.data.service
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST
+import retrofit2.http.Path
 import sopt.uni.data.entity.shortgame.MissionDetail
 import sopt.uni.data.source.remote.request.RequestCreateShortGameDto
 import sopt.uni.data.source.remote.response.ResponseCreateShortGameDto
@@ -15,4 +16,9 @@ interface ShortGameService {
     suspend fun postCreateShortGame(
         @Body request: RequestCreateShortGameDto,
     ): ResponseCreateShortGameDto
+
+    @GET("/api/mission/{missionCategoryId}")
+    suspend fun getMissionDetail(
+        @Path("missionCategoryId") missionCategoryId: Int,
+    ): MissionDetail
 }

--- a/app/src/main/java/sopt/uni/data/service/ShortGameService.kt
+++ b/app/src/main/java/sopt/uni/data/service/ShortGameService.kt
@@ -1,9 +1,18 @@
 package sopt.uni.data.service
 
+import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.POST
 import sopt.uni.data.entity.shortgame.MissionDetail
+import sopt.uni.data.source.remote.request.RequestCreateShortGameDto
+import sopt.uni.data.source.remote.response.ResponseCreateShortGameDto
 
 interface ShortGameService {
     @GET("/api/mission")
     suspend fun getMissionCategoryList(): List<MissionDetail>
+
+    @POST("/api/game/short")
+    suspend fun postCreateShortGame(
+        @Body request: RequestCreateShortGameDto,
+    ): ResponseCreateShortGameDto
 }

--- a/app/src/main/java/sopt/uni/data/service/ShortGameService.kt
+++ b/app/src/main/java/sopt/uni/data/service/ShortGameService.kt
@@ -7,6 +7,7 @@ import retrofit2.http.Path
 import sopt.uni.data.entity.shortgame.MissionDetail
 import sopt.uni.data.source.remote.request.RequestCreateShortGameDto
 import sopt.uni.data.source.remote.response.ResponseCreateShortGameDto
+import sopt.uni.data.source.remote.response.ResponseShortGameResultDto
 
 interface ShortGameService {
     @GET("/api/mission")
@@ -21,4 +22,9 @@ interface ShortGameService {
     suspend fun getMissionDetail(
         @Path("missionCategoryId") missionCategoryId: Int,
     ): MissionDetail
+
+    @GET("/api/game/short/{roundGameId}")
+    suspend fun getShortGameResult(
+        @Path("roundGameId") roundGameId: Int,
+    ): ResponseShortGameResultDto
 }

--- a/app/src/main/java/sopt/uni/data/source/remote/request/RequestCreateShortGameDto.kt
+++ b/app/src/main/java/sopt/uni/data/source/remote/request/RequestCreateShortGameDto.kt
@@ -1,0 +1,12 @@
+package sopt.uni.data.source.remote.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RequestCreateShortGameDto(
+    @SerialName("missionCategoryId")
+    val missionCategoryId: Int,
+    @SerialName("wishContent")
+    val wishContent: String,
+)

--- a/app/src/main/java/sopt/uni/data/source/remote/request/RequestRecordShortGameDto.kt
+++ b/app/src/main/java/sopt/uni/data/source/remote/request/RequestRecordShortGameDto.kt
@@ -1,3 +1,10 @@
 package sopt.uni.data.source.remote.request
 
-data class RequestRecordShortGameDto(val result: Boolean)
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RequestRecordShortGameDto(
+    @SerialName("result")
+    val result: Boolean
+)

--- a/app/src/main/java/sopt/uni/data/source/remote/request/RequestRecordShortGameDto.kt
+++ b/app/src/main/java/sopt/uni/data/source/remote/request/RequestRecordShortGameDto.kt
@@ -1,0 +1,3 @@
+package sopt.uni.data.source.remote.request
+
+data class RequestRecordShortGameDto(val result: Boolean)

--- a/app/src/main/java/sopt/uni/data/source/remote/response/ResponseCreateShortGameDto.kt
+++ b/app/src/main/java/sopt/uni/data/source/remote/response/ResponseCreateShortGameDto.kt
@@ -1,0 +1,16 @@
+package sopt.uni.data.source.remote.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import sopt.uni.data.entity.shortgame.RoundMission
+import sopt.uni.data.entity.shortgame.ShortGame
+
+@Serializable
+data class ResponseCreateShortGameDto(
+    @SerialName("shortGame")
+    val shortGame: ShortGame,
+    @SerialName("roundGameId")
+    val roundGameId: Int,
+    @SerialName("roundMission")
+    val roundMission: RoundMission,
+)

--- a/app/src/main/java/sopt/uni/data/source/remote/response/ResponseShortGameResultDto.kt
+++ b/app/src/main/java/sopt/uni/data/source/remote/response/ResponseShortGameResultDto.kt
@@ -1,10 +1,11 @@
-package sopt.uni.data.entity.shortgame
+package sopt.uni.data.source.remote.response
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import sopt.uni.data.entity.shortgame.RoundMission
 
 @Serializable
-data class ResponseShortGameResult(
+data class ResponseShortGameResultDto(
     @SerialName("myRoundMission")
     val myRoundMission: RoundMission,
     @SerialName("partnerRoundMission")

--- a/app/src/main/java/sopt/uni/di/RepositoryModule.kt
+++ b/app/src/main/java/sopt/uni/di/RepositoryModule.kt
@@ -10,6 +10,9 @@ import sopt.uni.data.repository.history.HistoryRepository
 import sopt.uni.data.repository.history.HistoryRepositoryImpl
 import sopt.uni.data.repository.onboarding.OnBoardingRepository
 import sopt.uni.data.repository.onboarding.OnBoardingRepositoryImpl
+import sopt.uni.data.repository.shortgame.ShortGameRepository
+import sopt.uni.data.repository.shortgame.ShortGameRepositoryImpl
+import sopt.uni.data.service.ShortGameService
 import javax.inject.Singleton
 
 @Module
@@ -23,6 +26,11 @@ object RepositoryModule {
     @Singleton
     fun provideOnBoardingRepository(onBoardingRepository: OnBoardingRepositoryImpl): OnBoardingRepository =
         onBoardingRepository
+
+    @Provides
+    @Singleton
+    fun provideShortGameRepository(shortGameService: ShortGameService): ShortGameRepository =
+        ShortGameRepositoryImpl(shortGameService)
 
     @Provides
     @Singleton

--- a/app/src/main/java/sopt/uni/di/ServiceModule.kt
+++ b/app/src/main/java/sopt/uni/di/ServiceModule.kt
@@ -8,6 +8,7 @@ import retrofit2.Retrofit
 import sopt.uni.data.service.AuthService
 import sopt.uni.data.service.HistoryService
 import sopt.uni.data.service.OnBoardingService
+import sopt.uni.data.service.ShortGameService
 import javax.inject.Singleton
 
 @Module
@@ -27,4 +28,8 @@ object ServiceModule {
     @Provides
     @Singleton
     fun provideOnBoardingService(retrofit: Retrofit): OnBoardingService = retrofit.create()
+
+    @Provides
+    @Singleton
+    fun provideShortGameService(retrofit: Retrofit): ShortGameService = retrofit.create()
 }

--- a/app/src/main/java/sopt/uni/presentation/shortgame/createshortgame/CreateShortGameViewModel.kt
+++ b/app/src/main/java/sopt/uni/presentation/shortgame/createshortgame/CreateShortGameViewModel.kt
@@ -1,18 +1,26 @@
 package sopt.uni.presentation.shortgame.createshortgame
 
+import android.util.Log
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.map
-import sopt.uni.data.entity.shortgame.Mission
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import sopt.uni.data.entity.shortgame.MissionDetail
+import sopt.uni.data.repository.shortgame.ShortGameRepository
+import javax.inject.Inject
 
-class CreateShortGameViewModel : ViewModel() {
+@HiltViewModel
+class CreateShortGameViewModel @Inject constructor(private val shortGameRepository: ShortGameRepository) :
+    ViewModel() {
     private val _selectedMissionId = MutableLiveData<Int>()
     val selectedMissionId = _selectedMissionId
 
     private val _roundGameId = MutableLiveData<Int>()
     val roundGameId = _roundGameId
 
-    private val _missionList = MutableLiveData<List<Mission>>()
+    private val _missionList = MutableLiveData<List<MissionDetail>>()
     val missionList = _missionList
 
     val wishContent = MutableLiveData<String>("")
@@ -25,22 +33,17 @@ class CreateShortGameViewModel : ViewModel() {
     val isCreateSuccess = _isCreateSuccess
 
     init {
-        setDummyList()
+        getMissionCategory()
     }
 
-    private fun setDummyList() {
-        val missionList = mutableListOf<Mission>()
-
-        for (i in 0..7) {
-            missionList.add(
-                Mission(
-                    image = "https://github.com/U-is-Ni-in-Korea/Android-United/assets/50603273/8c345eb3-d688-42bd-8585-a02f1016e213",
-                    title = "뀨$i",
-                    id = i,
-                ),
-            )
+    private fun getMissionCategory() {
+        viewModelScope.launch {
+            shortGameRepository.getMissionCategory().onSuccess {
+                _missionList.postValue(it)
+            }.onFailure {
+                // TODO: 실패시 예외처리
+            }
         }
-        _missionList.value = missionList
     }
 
     fun createShortGame() {

--- a/app/src/main/java/sopt/uni/presentation/shortgame/createshortgame/CreateShortGameViewModel.kt
+++ b/app/src/main/java/sopt/uni/presentation/shortgame/createshortgame/CreateShortGameViewModel.kt
@@ -1,6 +1,5 @@
 package sopt.uni.presentation.shortgame.createshortgame
 
-import android.util.Log
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.map
@@ -40,6 +39,7 @@ class CreateShortGameViewModel @Inject constructor(private val shortGameReposito
         viewModelScope.launch {
             shortGameRepository.getMissionCategory().onSuccess {
                 _missionList.postValue(it)
+                selectedMissionId.postValue(it[0].id)
             }.onFailure {
                 // TODO: 실패시 예외처리
             }
@@ -47,8 +47,17 @@ class CreateShortGameViewModel @Inject constructor(private val shortGameReposito
     }
 
     fun createShortGame() {
-        _isCreateSuccess.postValue(true)
-        _roundGameId.value = 1
+        viewModelScope.launch {
+            shortGameRepository.createShortGame(
+                selectedMissionId.value ?: return@launch,
+                wishContent.value ?: "",
+            ).onSuccess {
+                _roundGameId.value = it.roundGameId
+                _isCreateSuccess.value = true
+            }.onFailure {
+                // TODO: 실패시 예외처리
+            }
+        }
     }
 
     fun setSelectedMissionId(missionId: Int) {

--- a/app/src/main/java/sopt/uni/presentation/shortgame/createshortgame/MissionCategoryAdapter.kt
+++ b/app/src/main/java/sopt/uni/presentation/shortgame/createshortgame/MissionCategoryAdapter.kt
@@ -3,16 +3,16 @@ package sopt.uni.presentation.shortgame.createshortgame
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.ListAdapter
-import sopt.uni.data.entity.shortgame.Mission
+import sopt.uni.data.entity.shortgame.MissionDetail
 import sopt.uni.databinding.ItemMissionBinding
 import sopt.uni.presentation.entity.MissionIdPosition
 import sopt.uni.util.extension.ItemDiffCallback
 
 class MissionCategoryAdapter(
     private val goToMissionDetailClickListener: (MissionIdPosition) -> Unit,
-    private val selectMissionClickListener: (MissionIdPosition) -> Unit
-) : ListAdapter<Mission, MissionViewHolder>(
-    ItemDiffCallback<Mission>(
+    private val selectMissionClickListener: (MissionIdPosition) -> Unit,
+) : ListAdapter<MissionDetail, MissionViewHolder>(
+    ItemDiffCallback<MissionDetail>(
         onContentsTheSame = { old, new -> old == new },
         onItemsTheSame = { old, new -> old == new },
     ),
@@ -30,7 +30,7 @@ class MissionCategoryAdapter(
             position == selectedPosition,
             position,
             goToMissionDetailClickListener,
-            selectMissionClickListener
+            selectMissionClickListener,
         )
     }
 

--- a/app/src/main/java/sopt/uni/presentation/shortgame/createshortgame/MissionViewHolder.kt
+++ b/app/src/main/java/sopt/uni/presentation/shortgame/createshortgame/MissionViewHolder.kt
@@ -3,7 +3,7 @@ package sopt.uni.presentation.shortgame.createshortgame
 import androidx.recyclerview.widget.RecyclerView
 import coil.load
 import sopt.uni.R
-import sopt.uni.data.entity.shortgame.Mission
+import sopt.uni.data.entity.shortgame.MissionDetail
 import sopt.uni.databinding.ItemMissionBinding
 import sopt.uni.presentation.entity.MissionIdPosition
 
@@ -11,13 +11,12 @@ class MissionViewHolder(val binding: ItemMissionBinding) :
     RecyclerView.ViewHolder(binding.root) {
 
     fun onBind(
-        data: Mission,
+        data: MissionDetail,
         isSelected: Boolean,
         position: Int,
         goToMissionDetailClickListener: (MissionIdPosition) -> Unit,
-        selectMissionClickListener: (MissionIdPosition) -> Unit
+        selectMissionClickListener: (MissionIdPosition) -> Unit,
     ) {
-
         binding.apply {
             ivMission.load(data.image)
             tvMissionTitle.text = data.title
@@ -29,9 +28,10 @@ class MissionViewHolder(val binding: ItemMissionBinding) :
             }
         }
 
-        if (isSelected)
+        if (isSelected) {
             binding.cvBackground.setBackgroundResource(R.drawable.bg_mission_hover)
-        else
+        } else {
             binding.cvBackground.setBackgroundResource(0)
+        }
     }
 }

--- a/app/src/main/java/sopt/uni/presentation/shortgame/missiondetailcreate/MissionDetailCreateActivity.kt
+++ b/app/src/main/java/sopt/uni/presentation/shortgame/missiondetailcreate/MissionDetailCreateActivity.kt
@@ -3,6 +3,7 @@ package sopt.uni.presentation.shortgame.missiondetailcreate
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.viewModels
+import dagger.hilt.android.AndroidEntryPoint
 import sopt.uni.R
 import sopt.uni.databinding.ActivityMissionDetailCreateBinding
 import sopt.uni.presentation.entity.MissionIdPosition
@@ -10,7 +11,7 @@ import sopt.uni.presentation.shortgame.createshortgame.CreateShortGameActivity
 import sopt.uni.util.binding.BindingActivity
 import sopt.uni.util.extension.parcelable
 import sopt.uni.util.extension.setOnSingleClickListener
-
+@AndroidEntryPoint
 class MissionDetailCreateActivity : BindingActivity<ActivityMissionDetailCreateBinding>(R.layout.activity_mission_detail_create) {
 
     private val viewModel: MissionDetailCreateViewModel by viewModels()

--- a/app/src/main/java/sopt/uni/presentation/shortgame/missiondetailcreate/MissionDetailCreateViewModel.kt
+++ b/app/src/main/java/sopt/uni/presentation/shortgame/missiondetailcreate/MissionDetailCreateViewModel.kt
@@ -3,12 +3,21 @@ package sopt.uni.presentation.shortgame.missiondetailcreate
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import sopt.uni.data.entity.shortgame.MissionDetail
-import sopt.uni.data.entity.shortgame.MissionExample
+import sopt.uni.data.repository.shortgame.ShortGameRepository
 import sopt.uni.presentation.entity.MissionIdPosition
+import javax.inject.Inject
 
-class MissionDetailCreateViewModel(savedStateHandle: SavedStateHandle) : ViewModel() {
-    val missionId = savedStateHandle.get<MissionIdPosition>(MissionDetailCreateActivity.MISSION_ID_POSITION)
+@HiltViewModel
+class MissionDetailCreateViewModel @Inject constructor(
+    private val shortGameRepository: ShortGameRepository,
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+    val missionId =
+        savedStateHandle.get<MissionIdPosition>(MissionDetailCreateActivity.MISSION_ID_POSITION)?.id
 
     private val _missionDetail = MutableLiveData<MissionDetail>()
     val missionDetail = _missionDetail
@@ -17,15 +26,13 @@ class MissionDetailCreateViewModel(savedStateHandle: SavedStateHandle) : ViewMod
         setMissionDetail()
     }
 
-    fun setMissionDetail() {
-        _missionDetail.value = MissionDetail(
-            1,
-            "금지어 말하지 않기",
-            "금지이름 말하지 않는 게임입니다",
-            "본인에게 할당된 주제의 답변을 상대방이 맞춰야 하는 게임입니다.\n" + "단순 주제가 나와있는 미션이라면, 상대의 입장에서 해당 주제에 대한 답을 해주세요.\n" + "2지선다로 이루어진 미션이라면, 상대가 어떤 선지를 더 좋아할지에 대해 예상하여 답을 해주세요.",
-            "요리조리 피해보세요",
-            "https://github.com/U-is-Ni-in-Korea/Android-United/assets/50603273/8c345eb3-d688-42bd-8585-a02f1016e213",
-            listOf(MissionExample(1, "헐"), MissionExample(2, "대박")),
-        )
+    private fun setMissionDetail() {
+        viewModelScope.launch {
+            shortGameRepository.getMissionDetail(missionId ?: return@launch).onSuccess {
+                _missionDetail.postValue(it)
+            }.onFailure {
+                // TODO: 실패로직 구현
+            }
+        }
     }
 }

--- a/app/src/main/java/sopt/uni/presentation/shortgame/missiondetailrecord/MissionDetailRecordActivity.kt
+++ b/app/src/main/java/sopt/uni/presentation/shortgame/missiondetailrecord/MissionDetailRecordActivity.kt
@@ -4,18 +4,20 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.viewModels
+import dagger.hilt.android.AndroidEntryPoint
 import sopt.uni.R
 import sopt.uni.databinding.ActivityMissionDetailRecordBinding
 import sopt.uni.util.binding.BindingActivity
 
-class MissionDetailRecordActivity : BindingActivity<ActivityMissionDetailRecordBinding>(R.layout.activity_mission_detail_record) {
+@AndroidEntryPoint
+class MissionDetailRecordActivity :
+    BindingActivity<ActivityMissionDetailRecordBinding>(R.layout.activity_mission_detail_record) {
     private val viewModel: MissionDetailRecordViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
         binding.missionDetailReCordViewModel = viewModel
-        viewModel.setMissionDetail()
         setClickListener()
     }
 
@@ -32,6 +34,7 @@ class MissionDetailRecordActivity : BindingActivity<ActivityMissionDetailRecordB
             if (missionId != null) context.startActivity(getIntent(context, missionId))
         }
 
-        private fun getIntent(context: Context, missionId: Int) = Intent(context, MissionDetailRecordActivity::class.java).putExtra(MISSION_ID, missionId)
+        private fun getIntent(context: Context, missionId: Int) =
+            Intent(context, MissionDetailRecordActivity::class.java).putExtra(MISSION_ID, missionId)
     }
 }

--- a/app/src/main/java/sopt/uni/presentation/shortgame/missiondetailrecord/MissionDetailRecordViewModel.kt
+++ b/app/src/main/java/sopt/uni/presentation/shortgame/missiondetailrecord/MissionDetailRecordViewModel.kt
@@ -3,24 +3,34 @@ package sopt.uni.presentation.shortgame.missiondetailrecord
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import sopt.uni.data.entity.shortgame.MissionDetail
-import sopt.uni.data.entity.shortgame.MissionExample
+import sopt.uni.data.repository.shortgame.ShortGameRepository
+import javax.inject.Inject
 
-class MissionDetailRecordViewModel(savedStateHandle: SavedStateHandle) : ViewModel() {
+@HiltViewModel
+class MissionDetailRecordViewModel @Inject constructor(
+    private val shortGameRepository: ShortGameRepository,
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
     val missionId: Int = savedStateHandle.get<Int>(MissionDetailRecordActivity.MISSION_ID) ?: -1
 
     private val _missionDetail = MutableLiveData<MissionDetail>()
     val missionDetail = _missionDetail
 
-    fun setMissionDetail() {
-        _missionDetail.value = MissionDetail(
-            1,
-            "금지어 말하지 않기",
-            "금지이름 말하지 않는 게임입니다",
-            "본인에게 할당된 주제의 답변을 상대방이 맞춰야 하는 게임입니다.\n" + "단순 주제가 나와있는 미션이라면, 상대의 입장에서 해당 주제에 대한 답을 해주세요.\n" + "2지선다로 이루어진 미션이라면, 상대가 어떤 선지를 더 좋아할지에 대해 예상하여 답을 해주세요.",
-            "요리조리 피해보세요",
-            "https://github.com/U-is-Ni-in-Korea/Android-United/assets/50603273/8c345eb3-d688-42bd-8585-a02f1016e213",
-            listOf(MissionExample(1, "헐"), MissionExample(2, "대박")),
-        )
+    init {
+        setMissionDetail()
+    }
+
+    private fun setMissionDetail() {
+        viewModelScope.launch {
+            shortGameRepository.getMissionDetail(missionId).onSuccess {
+                _missionDetail.postValue(it)
+            }.onFailure {
+                // TODO: 실패로직 구현
+            }
+        }
     }
 }

--- a/app/src/main/java/sopt/uni/presentation/shortgame/missionrecord/MissionRecordActivity.kt
+++ b/app/src/main/java/sopt/uni/presentation/shortgame/missionrecord/MissionRecordActivity.kt
@@ -12,6 +12,7 @@ import sopt.uni.presentation.shortgame.missiondetailrecord.MissionDetailRecordAc
 import sopt.uni.presentation.shortgame.missionresult.MissionResultActivity
 import sopt.uni.util.binding.BindingActivity
 import sopt.uni.util.extension.setOnSingleClickListener
+import timber.log.Timber
 
 @AndroidEntryPoint
 class MissionRecordActivity :
@@ -29,10 +30,14 @@ class MissionRecordActivity :
 
     private fun cancelDialog() {
         CreateShortGameDialogFragment().apply {
-            titleText = this@MissionRecordActivity.resources.getString(R.string.mission_detatil_record_rule_title)
-            bodyText = this@MissionRecordActivity.resources.getString(R.string.mission_record_cancel_dialog_body)
-            confirmButtonText = this@MissionRecordActivity.resources.getString(R.string.dialog_ok_text)
-            dismissButtonText = this@MissionRecordActivity.resources.getString(R.string.dialog_cancel_text)
+            titleText =
+                this@MissionRecordActivity.resources.getString(R.string.mission_detatil_record_rule_title)
+            bodyText =
+                this@MissionRecordActivity.resources.getString(R.string.mission_record_cancel_dialog_body)
+            confirmButtonText =
+                this@MissionRecordActivity.resources.getString(R.string.dialog_ok_text)
+            dismissButtonText =
+                this@MissionRecordActivity.resources.getString(R.string.dialog_cancel_text)
             confirmClickListener = {
                 viewModel.requestStopMission()
                 this.dismiss()
@@ -44,7 +49,7 @@ class MissionRecordActivity :
     }
 
     private fun setViewModelObserve() {
-        viewModel.isMissionCancelSuccess.observe(this) {
+        viewModel.isMissionDeleteSuccess.observe(this) {
             if (it) finish()
         }
         viewModel.isMissionRequestSuccess.observe(this) {
@@ -65,6 +70,7 @@ class MissionRecordActivity :
                     this@MissionRecordActivity,
                     viewModel.missionId.value,
                 )
+                Timber.tag("testt4").d(viewModel.missionId.value.toString())
             }
             ivClose.setOnSingleClickListener {
                 finish()
@@ -85,6 +91,7 @@ class MissionRecordActivity :
             context.startActivity(getIntent(context, roundGameId))
         }
 
-        private fun getIntent(context: Context, roundGameId: Int) = Intent(context, MissionRecordActivity::class.java).putExtra(ROUND_GAME_ID, roundGameId)
+        private fun getIntent(context: Context, roundGameId: Int) =
+            Intent(context, MissionRecordActivity::class.java).putExtra(ROUND_GAME_ID, roundGameId)
     }
 }

--- a/app/src/main/java/sopt/uni/presentation/shortgame/missionrecord/MissionRecordViewModel.kt
+++ b/app/src/main/java/sopt/uni/presentation/shortgame/missionrecord/MissionRecordViewModel.kt
@@ -5,13 +5,13 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.map
-import sopt.uni.data.entity.shortgame.ResponseShortGameResult
+import sopt.uni.data.source.remote.response.ResponseShortGameResultDto
 
 class MissionRecordViewModel(private val savedStateHandle: SavedStateHandle) : ViewModel() {
     val roundGameId: Int = savedStateHandle.get<Int>(MissionRecordActivity.ROUND_GAME_ID) ?: -1
 
-    private val _missionResult = MutableLiveData<ResponseShortGameResult>()
-    val missionResult: LiveData<ResponseShortGameResult> = _missionResult
+    private val _missionResult = MutableLiveData<ResponseShortGameResultDto>()
+    val missionResult: LiveData<ResponseShortGameResultDto> = _missionResult
 
     private val _isMissionCancelSuccess = MutableLiveData<Boolean>(false)
     val isMissionCancelSuccess = _isMissionCancelSuccess

--- a/app/src/main/java/sopt/uni/presentation/shortgame/missionrecord/MissionRecordViewModel.kt
+++ b/app/src/main/java/sopt/uni/presentation/shortgame/missionrecord/MissionRecordViewModel.kt
@@ -4,33 +4,68 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.map
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import sopt.uni.data.entity.shortgame.RoundMission
+import sopt.uni.data.repository.shortgame.ShortGameRepository
 import sopt.uni.data.source.remote.response.ResponseShortGameResultDto
+import timber.log.Timber
+import javax.inject.Inject
 
-class MissionRecordViewModel(private val savedStateHandle: SavedStateHandle) : ViewModel() {
+@HiltViewModel
+class MissionRecordViewModel @Inject constructor(
+    private val shortGameRepository: ShortGameRepository,
+    private val savedStateHandle: SavedStateHandle,
+) : ViewModel() {
     val roundGameId: Int = savedStateHandle.get<Int>(MissionRecordActivity.ROUND_GAME_ID) ?: -1
 
-    private val _missionResult = MutableLiveData<ResponseShortGameResultDto>()
-    val missionResult: LiveData<ResponseShortGameResultDto> = _missionResult
-
-    private val _isMissionCancelSuccess = MutableLiveData<Boolean>(false)
-    val isMissionCancelSuccess = _isMissionCancelSuccess
+    private val _isMissionDeleteSuccess = MutableLiveData<Boolean>(false)
+    val isMissionDeleteSuccess = _isMissionDeleteSuccess
 
     private val _isMissionRequestSuccess = MutableLiveData<Boolean>(false)
     val isMissionRequestSuccess = _isMissionRequestSuccess
 
-    val myMissionResult = missionResult.map { it.myRoundMission }
-    val missionId = myMissionResult.map { it.missionContent.id }
+    private val _myMissionResult = MutableLiveData<RoundMission>()
+    val myMissionResult = _myMissionResult
 
-    fun loadMissionRecord() {
-        // TODO: Get 승부기록뷰 정보
+    private val _missionId = MutableLiveData<Int>()
+    val missionId = _missionId
+
+    init {
+        setMissionRecord()
+    }
+
+    private fun setMissionRecord() {
+        viewModelScope.launch {
+            shortGameRepository.getShortGameResult(roundGameId).onSuccess {
+                myMissionResult.value = it.myRoundMission
+                missionId.value = it.myRoundMission.missionContent.missionCategory.id
+            }.onFailure {
+                // TODO: 실패 로직 구현
+            }
+        }
     }
 
     fun requestMission(missionRequest: Boolean) {
-        _isMissionRequestSuccess.postValue(true)
+        viewModelScope.launch {
+            shortGameRepository.recordShortGame(roundGameId, missionRequest).onSuccess {
+                _isMissionRequestSuccess.postValue(true)
+            }.onFailure {
+                // TODO: 실패 로직 구현
+                Timber.tag("testt2").d(it.toString())
+            }
+        }
     }
 
     fun requestStopMission() {
-        _isMissionCancelSuccess.postValue(true)
+        viewModelScope.launch {
+            shortGameRepository.deleteShortGame(roundGameId).onSuccess {
+                _isMissionDeleteSuccess.postValue(true)
+            }.onFailure {
+                // TODO: 실패 로직 구현
+                Timber.tag("testt3").d(it.toString())
+            }
+        }
     }
 }

--- a/app/src/main/java/sopt/uni/presentation/shortgame/missionrecord/MissionRecordViewModel.kt
+++ b/app/src/main/java/sopt/uni/presentation/shortgame/missionrecord/MissionRecordViewModel.kt
@@ -1,6 +1,5 @@
 package sopt.uni.presentation.shortgame.missionrecord
 
-import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
@@ -9,7 +8,6 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import sopt.uni.data.entity.shortgame.RoundMission
 import sopt.uni.data.repository.shortgame.ShortGameRepository
-import sopt.uni.data.source.remote.response.ResponseShortGameResultDto
 import timber.log.Timber
 import javax.inject.Inject
 

--- a/app/src/main/java/sopt/uni/presentation/shortgame/missionresult/MissionResultActivity.kt
+++ b/app/src/main/java/sopt/uni/presentation/shortgame/missionresult/MissionResultActivity.kt
@@ -7,6 +7,7 @@ import android.view.View
 import android.widget.TextView
 import androidx.activity.viewModels
 import androidx.databinding.BindingAdapter
+import dagger.hilt.android.AndroidEntryPoint
 import sopt.uni.R
 import sopt.uni.data.entity.shortgame.MissionResultState
 import sopt.uni.databinding.ActivityMissionResultBinding
@@ -14,6 +15,7 @@ import sopt.uni.presentation.shortgame.missionrecord.MissionRecordActivity
 import sopt.uni.util.binding.BindingActivity
 import sopt.uni.util.extension.setOnSingleClickListener
 
+@AndroidEntryPoint
 class MissionResultActivity :
     BindingActivity<ActivityMissionResultBinding>(R.layout.activity_mission_result) {
 
@@ -41,15 +43,14 @@ class MissionResultActivity :
 
     private fun setResultImageText(state: MissionResultState) {
         val imageArray = this.resources.obtainTypedArray(R.array.result_state_image)
-        val stringArray = this.resources.obtainTypedArray(R.array.result_state_text)
+        val stringArray = this.resources.getStringArray(R.array.result_state_text)
         binding.ivMissionResult.setImageResource(imageArray.getResourceId(state.order, 0))
-        binding.tvMyMissionResult.text = stringArray.getString(state.order)
+        binding.tvMissionResultScript.text = stringArray[state.order]
     }
 
     private fun setButtonVisible(state: MissionResultState) {
         when (state) {
             MissionResultState.WIN -> binding.btnGoWish.visibility = View.VISIBLE
-
             else -> binding.btnGoHome.visibility = View.VISIBLE
         }
     }
@@ -92,7 +93,7 @@ class MissionResultActivity :
                 view.text = view.context.getString(R.string.mission_result_failure)
                 view.background = view.context.getDrawable(R.drawable.wish_ment_pink_rectangle)
             } else {
-                val dateString = date.split(" ")[1].substring(5)
+                val dateString = date.split("T")[1].substring(0, 5)
                 view.text =
                     "$dateString ${view.context.getString(R.string.mission_result_complete)}"
                 view.background = view.context.getDrawable(R.drawable.wish_ment_green_rectangle)

--- a/app/src/main/java/sopt/uni/presentation/shortgame/missionresult/MissionResultViewModel.kt
+++ b/app/src/main/java/sopt/uni/presentation/shortgame/missionresult/MissionResultViewModel.kt
@@ -6,14 +6,14 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.map
 import sopt.uni.data.entity.shortgame.MissionResultState
-import sopt.uni.data.entity.shortgame.ResponseShortGameResult
+import sopt.uni.data.source.remote.response.ResponseShortGameResultDto
 import sopt.uni.presentation.shortgame.missionrecord.MissionRecordActivity
 
 class MissionResultViewModel(savedStateHandle: SavedStateHandle) : ViewModel() {
     // TODO: response 네이밍 바꾸고 Result로 감싸서 성공 실패 분기 처리하기
     val roundGameId: Int = savedStateHandle.get<Int>(MissionRecordActivity.ROUND_GAME_ID) ?: -1
-    private val _missionResult = MutableLiveData<ResponseShortGameResult>()
-    val missionResult: LiveData<ResponseShortGameResult> = _missionResult
+    private val _missionResult = MutableLiveData<ResponseShortGameResultDto>()
+    val missionResult: LiveData<ResponseShortGameResultDto> = _missionResult
     val myMissionResult = missionResult.map { it.myRoundMission }
     val partnerMissionResult = missionResult.map { it.partnerRoundMission }
     val myMissionResultState =

--- a/app/src/main/java/sopt/uni/presentation/shortgame/missionresult/MissionResultViewModel.kt
+++ b/app/src/main/java/sopt/uni/presentation/shortgame/missionresult/MissionResultViewModel.kt
@@ -1,21 +1,51 @@
 package sopt.uni.presentation.shortgame.missionresult
 
-import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.map
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import sopt.uni.data.entity.shortgame.MissionResultState
-import sopt.uni.data.source.remote.response.ResponseShortGameResultDto
+import sopt.uni.data.entity.shortgame.RoundMission
+import sopt.uni.data.repository.shortgame.ShortGameRepository
 import sopt.uni.presentation.shortgame.missionrecord.MissionRecordActivity
+import javax.inject.Inject
 
-class MissionResultViewModel(savedStateHandle: SavedStateHandle) : ViewModel() {
-    // TODO: response 네이밍 바꾸고 Result로 감싸서 성공 실패 분기 처리하기
+@HiltViewModel
+class MissionResultViewModel @Inject constructor(
+    private val shortGameRepository: ShortGameRepository,
+    private val savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
     val roundGameId: Int = savedStateHandle.get<Int>(MissionRecordActivity.ROUND_GAME_ID) ?: -1
-    private val _missionResult = MutableLiveData<ResponseShortGameResultDto>()
-    val missionResult: LiveData<ResponseShortGameResultDto> = _missionResult
-    val myMissionResult = missionResult.map { it.myRoundMission }
-    val partnerMissionResult = missionResult.map { it.partnerRoundMission }
-    val myMissionResultState =
-        myMissionResult.map { MissionResultState.getMissionResultType(it.finalResult) }
+
+    private val _myMissionResult = MutableLiveData<RoundMission>()
+    val myMissionResult = _myMissionResult
+
+    private val _partnerMissionResult = MutableLiveData<RoundMission?>()
+    val partnerMissionResult = _partnerMissionResult
+
+    private val _myMissionResultState = MutableLiveData<MissionResultState>()
+    val myMissionResultState = _myMissionResultState
+
+    init {
+        setMissionRecord()
+    }
+
+    private fun setMissionRecord() {
+        viewModelScope.launch {
+            shortGameRepository.getShortGameResult(roundGameId).onSuccess {
+                _myMissionResult.value = it.myRoundMission
+                if (it.partnerRoundMission != null) {
+                    _partnerMissionResult.value =
+                        it.partnerRoundMission
+                }
+                _myMissionResultState.value =
+                    MissionResultState.getMissionResultType(it.myRoundMission.finalResult)
+            }.onFailure {
+                // TODO: 실패 로직 구현
+            }
+        }
+    }
 }

--- a/app/src/main/res/layout/activity_mission_result.xml
+++ b/app/src/main/res/layout/activity_mission_result.xml
@@ -258,7 +258,7 @@
                 android:layout_marginBottom="29dp"
                 android:background="@drawable/bg_mission_image_round"
                 android:padding="12dp"
-                android:text="@string/mission_result_go_wish"
+                android:text="@string/mission_result_go_home"
                 android:textColor="@color/Lightblue_600"
                 android:visibility="invisible"
                 app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/layout/item_mission.xml
+++ b/app/src/main/res/layout/item_mission.xml
@@ -2,13 +2,6 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <data>
-
-        <variable
-            name="mission"
-            type="sopt.uni.data.entity.shortgame.Mission" />
-    </data>
-
     <androidx.cardview.widget.CardView
         android:id="@+id/cv_background"
         android:layout_width="match_parent"

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -8,10 +8,10 @@
         <item>@drawable/mission_undecided</item>
     </integer-array>
 
-    <integer-array name="result_state_text">
+    <string-array name="result_state_text">
         <item>@string/mission_result_win</item>
         <item>@string/mission_result_lose</item>
         <item>@string/mission_result_draw</item>
         <item>@string/mission_result_undecided</item>
-    </integer-array>
+    </string-array>
 </resources>


### PR DESCRIPTION
## 📌 관련 이슈
closed #61 

## 📷 screenshot
https://github.com/U-is-Ni-in-Korea/Android-United/assets/50603273/473133e1-a59b-4d0a-8af4-ff31d68a0d17

## 📝 Work Desciption
- 한판승부생성 미션카테고리 API 연동
- 한판승부생성 생성 API 연동
- 미션상세 API 연동
- 한판승부기록 정보 API 연동
- 한판승부기록 미션 성공,실패 API 연동
- 한판승부기록 승부 그만두기 API 연동

## 📚 Reference 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
