### PR TITLE
response에 couple_id 추가

### DIFF
--- a/app/src/main/java/sopt/uni/data/source/remote/response/ResponseAuthDto.kt
+++ b/app/src/main/java/sopt/uni/data/source/remote/response/ResponseAuthDto.kt
@@ -10,6 +10,8 @@ data class ResponseAuthDto(
     val accessToken: String,
     @SerialName("refresh_token")
     val refreshToken: String?,
+    @SerialName("couple_id")
+    val coupleId: Int?,
 ) {
     fun toToken(): Token = Token(accessToken = this.accessToken, refreshToken = this.refreshToken)
 }


### PR DESCRIPTION
## 📌 관련 이슈
- #108 



## 📷 screenshot
<!-- 시연영상을 업로드해주세요. -->

## 📝 Work Desciption
<!-- 작업한 내용을 설명해주세요. -->
1. 헤더에 값을 저장하지 못해 헤더가 없이 API 요청을 한다는 에러 메세지 발생
2. auth 쪽에서 커플 id가 추가됨에 따라 Response 수정
3. 정상적으로 실형

## 📚 Reference 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
