### PR TITLE
Feature/#94 홈 스코어 보드

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -127,13 +127,6 @@ dependencies {
     implementation "androidx.work:work-runtime:2.8.1"
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.1'
 
-
-    // Glide Transformations
-    implementation 'jp.wasabeef:glide-transformations:4.3.0'
-
-    // BlurView
-    implementation 'com.github.Dimezis:BlurView:version-2.0.3'
-
     //OSS Licenses Gradle Plugin
     implementation 'com.google.android.gms:play-services-oss-licenses:17.0.1'
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -117,6 +117,9 @@ dependencies {
     //shimmer-android
     implementation "com.facebook.shimmer:shimmer:0.5.0"
 
+    // Glide
+    implementation 'com.github.bumptech.glide:glide:4.16.0'
+
     //progressbar
     implementation 'com.mikhaellopez:circularprogressbar:3.1.0'
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -131,6 +131,9 @@ dependencies {
     // Glide Transformations
     implementation 'jp.wasabeef:glide-transformations:4.3.0'
 
+    // BlurView
+    implementation 'com.github.Dimezis:BlurView:version-2.0.3'
+
     //OSS Licenses Gradle Plugin
     implementation 'com.google.android.gms:play-services-oss-licenses:17.0.1'
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -124,6 +124,10 @@ dependencies {
     implementation "androidx.work:work-runtime:2.8.1"
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.1'
 
+
+    // Glide Transformations
+    implementation 'jp.wasabeef:glide-transformations:4.3.0'
+
     //OSS Licenses Gradle Plugin
     implementation 'com.google.android.gms:play-services-oss-licenses:17.0.1'
 

--- a/app/src/main/java/sopt/uni/presentation/home/HomeActivity.kt
+++ b/app/src/main/java/sopt/uni/presentation/home/HomeActivity.kt
@@ -1,12 +1,6 @@
 package sopt.uni.presentation.home
 
-import android.graphics.Bitmap
-import android.graphics.BitmapFactory
-import android.graphics.BlurMaskFilter
-import android.graphics.Canvas
-import android.graphics.Paint
 import android.os.Bundle
-import android.view.View
 import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.lifecycle.lifecycleScope
@@ -39,7 +33,6 @@ class HomeActivity : BindingActivity<ActivityHomeBinding>(R.layout.activity_home
 
         binding.viewModel = homeViewModel
 
-        setScoreBoardBLurEffect()
         moveToHistory()
         getRoundResult()
         moveToShortGame()
@@ -66,24 +59,6 @@ class HomeActivity : BindingActivity<ActivityHomeBinding>(R.layout.activity_home
         super.onResume()
         result = ""
         homeViewModel.fetchHomeInfo()
-    }
-
-    private fun setScoreBoardBLurEffect() {
-        with(binding) {
-            scoreBoardBackground.setLayerType(View.LAYER_TYPE_SOFTWARE, null)
-
-            val originalBitmap =
-                BitmapFactory.decodeResource(resources, R.drawable.score_board)
-            val blurredBitmap = originalBitmap.copy(Bitmap.Config.ARGB_8888, true)
-
-            val paint = Paint()
-            paint.maskFilter = BlurMaskFilter(50f, BlurMaskFilter.Blur.NORMAL)
-
-            val canvas = Canvas(blurredBitmap)
-            canvas.drawBitmap(blurredBitmap, 0f, 0f, paint)
-
-            scoreBoardBackground.setImageBitmap(blurredBitmap)
-        }
     }
 
     private fun moveToShortGame() {

--- a/app/src/main/java/sopt/uni/presentation/home/HomeActivity.kt
+++ b/app/src/main/java/sopt/uni/presentation/home/HomeActivity.kt
@@ -1,6 +1,12 @@
 package sopt.uni.presentation.home
 
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.BlurMaskFilter
+import android.graphics.Canvas
+import android.graphics.Paint
 import android.os.Bundle
+import android.view.View
 import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.lifecycle.lifecycleScope
@@ -33,6 +39,7 @@ class HomeActivity : BindingActivity<ActivityHomeBinding>(R.layout.activity_home
 
         binding.viewModel = homeViewModel
 
+        setScoreBoardBLurEffect()
         moveToHistory()
         getRoundResult()
         moveToShortGame()
@@ -59,6 +66,24 @@ class HomeActivity : BindingActivity<ActivityHomeBinding>(R.layout.activity_home
         super.onResume()
         result = ""
         homeViewModel.fetchHomeInfo()
+    }
+
+    private fun setScoreBoardBLurEffect() {
+        with(binding) {
+            scoreBoardBackground.setLayerType(View.LAYER_TYPE_SOFTWARE, null)
+
+            val originalBitmap =
+                BitmapFactory.decodeResource(resources, R.drawable.score_board)
+            val blurredBitmap = originalBitmap.copy(Bitmap.Config.ARGB_8888, true)
+
+            val paint = Paint()
+            paint.maskFilter = BlurMaskFilter(50f, BlurMaskFilter.Blur.NORMAL)
+
+            val canvas = Canvas(blurredBitmap)
+            canvas.drawBitmap(blurredBitmap, 0f, 0f, paint)
+
+            scoreBoardBackground.setImageBitmap(blurredBitmap)
+        }
     }
 
     private fun moveToShortGame() {

--- a/app/src/main/res/drawable/bg_score_board.xml
+++ b/app/src/main/res/drawable/bg_score_board.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <solid android:color="@color/white" />
+    <corners android:radius="20dp" />
+
+</shape>

--- a/app/src/main/res/drawable/bg_score_board.xml
+++ b/app/src/main/res/drawable/bg_score_board.xml
@@ -2,7 +2,7 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
 
-    <solid android:color="@color/white" />
+    <solid android:color="#30FFFFFF" />
     <corners android:radius="20dp" />
 
 </shape>

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -226,10 +226,11 @@
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
-        <View
+        <ImageView
+            android:id="@+id/score_board_background"
             android:layout_width="0dp"
             android:layout_height="0dp"
-            android:background="@drawable/bg_score_board"
+            android:src="@drawable/bg_score_board"
             app:layout_constraintTop_toTopOf="@id/cl_score_board"
             app:layout_constraintBottom_toBottomOf="@id/cl_score_board"
             app:layout_constraintStart_toStartOf="@id/cl_score_board"

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -57,14 +57,30 @@
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
+        <com.google.android.material.imageview.ShapeableImageView
+            android:id="@+id/iv_score_board"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:elevation="4dp"
+            android:scaleType="centerCrop"
+            android:src="@drawable/score_board"
+            android:translationZ="2dp"
+            app:layout_constraintBottom_toBottomOf="@id/cl_score_board"
+            app:layout_constraintEnd_toEndOf="@id/cl_score_board"
+            app:layout_constraintStart_toStartOf="@id/cl_score_board"
+            app:layout_constraintTop_toTopOf="@id/cl_score_board"
+            app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.App.CornerRadius20dp" />
+
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/cl_score_board"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="16dp"
             android:layout_marginVertical="20dp"
+            android:background="@null"
             android:elevation="8dp"
             android:paddingVertical="20dp"
+            android:translationZ="10dp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/cl_home_header">
@@ -226,16 +242,6 @@
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
-        <ImageView
-            android:id="@+id/score_board_background"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:src="@drawable/bg_score_board"
-            app:layout_constraintTop_toTopOf="@id/cl_score_board"
-            app:layout_constraintBottom_toBottomOf="@id/cl_score_board"
-            app:layout_constraintStart_toStartOf="@id/cl_score_board"
-            app:layout_constraintEnd_toEndOf="@id/cl_score_board"
-            />
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/cl_game_title"

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -63,7 +63,6 @@
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="16dp"
             android:layout_marginVertical="20dp"
-            android:background="@drawable/score_board"
             android:elevation="8dp"
             android:paddingVertical="20dp"
             app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -226,6 +226,15 @@
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
+        <View
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="@drawable/bg_score_board"
+            app:layout_constraintTop_toTopOf="@id/cl_score_board"
+            app:layout_constraintBottom_toBottomOf="@id/cl_score_board"
+            app:layout_constraintStart_toStartOf="@id/cl_score_board"
+            app:layout_constraintEnd_toEndOf="@id/cl_score_board"
+            />
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/cl_game_title"

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -33,4 +33,8 @@
         <item name="fontFamily">@font/pretendard</item>
     </style>
 
+    <style name="ShapeAppearanceOverlay.App.CornerRadius20dp" parent="">
+        <item name="cornerSize">10%</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
## 📌 관련 이슈
<!— 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 —>
- #94 

## 📷 screenshot
<!-- 시연영상을 업로드해주세요. -->
![image](https://github.com/U-is-Ni-in-Korea/Android-United/assets/98825364/b29eea2d-9ee4-4b8c-90a3-909b57aa4e6e)


## 📝 Work Desciption
<!-- 작업한 내용을 설명해주세요. -->
- Glide Transformation
- BlureView
- Blurry
- Bitmap
- Maskfliter
- RenderScript
위의 라이브러리들을 적용했으나, 투명도가 있는 layout blur 구현에는 맞지 않은 것 같아서 적용하지 못하였습니다.
이미지에 블러를 처리하는 것이 아닌, 레이아웃 배경에 블러를 처리하는 방법을 찾지 못했습니다.. 

## 📚 Reference 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
- 더 나은 개선점이 있으면 언제든지 연락주십쇼.. 