### PR TITLE
#119 / 재로그인시 커플 ID가 이미 있을 시 닉네임 설정 건너뛰기

### DIFF
--- a/app/src/main/java/sopt/uni/data/repository/auth/AuthRepository.kt
+++ b/app/src/main/java/sopt/uni/data/repository/auth/AuthRepository.kt
@@ -1,9 +1,9 @@
 package sopt.uni.data.repository.auth
 
-import sopt.uni.data.entity.auth.Token
+import sopt.uni.data.source.remote.response.ResponseAuthDto
 
 interface AuthRepository {
-    suspend fun getToken(social: String, code: String): Result<Token>
+    suspend fun getToken(social: String, code: String): Result<ResponseAuthDto>
 
     suspend fun initToken(accessToken: String, refreshToken: String)
 

--- a/app/src/main/java/sopt/uni/data/repository/auth/AuthRepositoryImpl.kt
+++ b/app/src/main/java/sopt/uni/data/repository/auth/AuthRepositoryImpl.kt
@@ -3,14 +3,15 @@ package sopt.uni.data.repository.auth
 import sopt.uni.data.datasource.remote.AuthDatasource
 import sopt.uni.data.entity.auth.Token
 import sopt.uni.data.source.remote.request.RequestAuthDto
+import sopt.uni.data.source.remote.response.ResponseAuthDto
 import javax.inject.Inject
 
 class AuthRepositoryImpl @Inject constructor(
     private val authDatasource: AuthDatasource,
 ) : AuthRepository {
-    override suspend fun getToken(social: String, code: String): Result<Token> =
+    override suspend fun getToken(social: String, code: String): Result<ResponseAuthDto> =
         kotlin.runCatching {
-            authDatasource.getToken(social, RequestAuthDto(code)).toToken()
+            authDatasource.getToken(social, RequestAuthDto(code))
         }.onSuccess {
             Result.success(it)
         }.onFailure {

--- a/app/src/main/java/sopt/uni/data/source/remote/response/ResponseAuthDto.kt
+++ b/app/src/main/java/sopt/uni/data/source/remote/response/ResponseAuthDto.kt
@@ -2,7 +2,6 @@ package sopt.uni.data.source.remote.response
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import sopt.uni.data.entity.auth.Token
 
 @Serializable
 data class ResponseAuthDto(
@@ -12,6 +11,4 @@ data class ResponseAuthDto(
     val refreshToken: String?,
     @SerialName("couple_id")
     val coupleId: Int?,
-) {
-    fun toToken(): Token = Token(accessToken = this.accessToken, refreshToken = this.refreshToken)
-}
+)

--- a/app/src/main/java/sopt/uni/presentation/login/LoginActivity.kt
+++ b/app/src/main/java/sopt/uni/presentation/login/LoginActivity.kt
@@ -77,14 +77,15 @@ class LoginActivity : BindingActivity<ActivityLoginBinding>(R.layout.activity_lo
                 .collect {
                     when (it) {
                         is KakaoLoginService.LoginState.Success -> {
-                            this@LoginActivity.showToast(getString(R.string.success_kakao_login))
                             loginViewModel.getAccessToken("kakao", it.token)
                             when (loginViewModel.loginResult.value) {
                                 is LoginViewModel.SparkleLoginState.Success -> {
+                                    this@LoginActivity.showToast(getString(R.string.success_kakao_login))
                                     startActivity<NickNameActivity>()
                                 }
 
                                 is LoginViewModel.SparkleLoginState.AlreadyCoupled -> {
+                                    this@LoginActivity.showToast(getString(R.string.success_kakao_login))
                                     startActivity<HomeActivity>()
                                 }
 
@@ -96,8 +97,6 @@ class LoginActivity : BindingActivity<ActivityLoginBinding>(R.layout.activity_lo
                                     Timber.d("Login Init")
                                 }
                             }
-
-//                            }
                         }
 
                         is KakaoLoginService.LoginState.Failure -> {
@@ -161,8 +160,25 @@ class LoginActivity : BindingActivity<ActivityLoginBinding>(R.layout.activity_lo
             .addOnCompleteListener(this) { task ->
                 if (task.isSuccessful) {
                     Timber.e("signInWithCredential:success")
-                    startActivity<NickNameActivity>()
-                    this@LoginActivity.showToast(getString(R.string.success_google_login))
+                    when (loginViewModel.loginResult.value) {
+                        is LoginViewModel.SparkleLoginState.Success -> {
+                            this@LoginActivity.showToast(getString(R.string.success_google_login))
+                            startActivity<NickNameActivity>()
+                        }
+
+                        is LoginViewModel.SparkleLoginState.AlreadyCoupled -> {
+                            this@LoginActivity.showToast(getString(R.string.success_google_login))
+                            startActivity<HomeActivity>()
+                        }
+
+                        is LoginViewModel.SparkleLoginState.Failure -> {
+                            Timber.e("Login Failed")
+                        }
+
+                        is LoginViewModel.SparkleLoginState.Init -> {
+                            Timber.d("Login Init")
+                        }
+                    }
                 } else {
                     Timber.e("signInWithCredential:failure", task.exception)
                 }

--- a/app/src/main/java/sopt/uni/presentation/login/LoginActivity.kt
+++ b/app/src/main/java/sopt/uni/presentation/login/LoginActivity.kt
@@ -22,6 +22,7 @@ import sopt.uni.BuildConfig.GOOGLE_CLIENT_ID
 import sopt.uni.R
 import sopt.uni.data.service.KakaoLoginService
 import sopt.uni.databinding.ActivityLoginBinding
+import sopt.uni.presentation.home.HomeActivity
 import sopt.uni.presentation.invite.NickNameActivity
 import sopt.uni.util.binding.BindingActivity
 import sopt.uni.util.extension.setOnSingleClickListener
@@ -76,10 +77,27 @@ class LoginActivity : BindingActivity<ActivityLoginBinding>(R.layout.activity_lo
                 .collect {
                     when (it) {
                         is KakaoLoginService.LoginState.Success -> {
-                            startActivity<NickNameActivity>()
                             this@LoginActivity.showToast(getString(R.string.success_kakao_login))
                             loginViewModel.getAccessToken("kakao", it.token)
-                            Timber.e("Kakao Login Success ${it.token} ${it.id}")
+                            when (loginViewModel.loginResult.value) {
+                                is LoginViewModel.SparkleLoginState.Success -> {
+                                    startActivity<NickNameActivity>()
+                                }
+
+                                is LoginViewModel.SparkleLoginState.AlreadyCoupled -> {
+                                    startActivity<HomeActivity>()
+                                }
+
+                                is LoginViewModel.SparkleLoginState.Failure -> {
+                                    Timber.e("Login Failed")
+                                }
+
+                                is LoginViewModel.SparkleLoginState.Init -> {
+                                    Timber.d("Login Init")
+                                }
+                            }
+
+//                            }
                         }
 
                         is KakaoLoginService.LoginState.Failure -> {

--- a/app/src/main/java/sopt/uni/presentation/login/LoginViewModel.kt
+++ b/app/src/main/java/sopt/uni/presentation/login/LoginViewModel.kt
@@ -24,11 +24,16 @@ class LoginViewModel @Inject constructor(
     fun getAccessToken(social: String, code: String) {
         viewModelScope.launch {
             authRepository.getToken(social, code)
-                .onSuccess { token ->
-                    SparkleStorage.accessToken = token.toToken().accessToken
-                    _loginResult.value = SparkleLoginState.Success
+                .onSuccess { authDto ->
+                    SparkleStorage.accessToken = authDto.accessToken
                     Timber.tag("accessToken")
-                        .d("getAccessToken with server: ${token.toToken().accessToken}")
+                        .d("getAccessToken with server: ${authDto.accessToken}")
+
+                    if (authDto.coupleId == null) {
+                        _loginResult.value = SparkleLoginState.Success
+                    } else {
+                        _loginResult.value = SparkleLoginState.AlreadyCoupled
+                    }
                 }.onFailure {
                     _loginResult.value = SparkleLoginState.Failure(it.message ?: "로그인에 실패했습니다.")
                 }

--- a/app/src/main/java/sopt/uni/presentation/login/LoginViewModel.kt
+++ b/app/src/main/java/sopt/uni/presentation/login/LoginViewModel.kt
@@ -17,26 +17,27 @@ class LoginViewModel @Inject constructor(
     private val authRepository: AuthRepository,
 ) : ViewModel() {
 
-    private val _loginResult: MutableStateFlow<InHouseLoginState> =
-        MutableStateFlow(InHouseLoginState.Init)
-    val loginResult: StateFlow<InHouseLoginState> = _loginResult.asStateFlow()
+    private val _loginResult: MutableStateFlow<SparkleLoginState> =
+        MutableStateFlow(SparkleLoginState.Init)
+    val loginResult: StateFlow<SparkleLoginState> = _loginResult.asStateFlow()
 
     fun getAccessToken(social: String, code: String) {
         viewModelScope.launch {
             authRepository.getToken(social, code)
                 .onSuccess { token ->
                     SparkleStorage.accessToken = token.toToken().accessToken
-                    _loginResult.value = InHouseLoginState.Success
-                    Timber.tag("accessToken").d("getAccessToken with server: ${token.toToken().accessToken}")
+                    _loginResult.value = SparkleLoginState.Success
+                    Timber.tag("accessToken")
+                        .d("getAccessToken with server: ${token.toToken().accessToken}")
                 }.onFailure {
-                    _loginResult.value = InHouseLoginState.Failure(it.message ?: "로그인에 실패했습니다.")
+                    _loginResult.value = SparkleLoginState.Failure(it.message ?: "로그인에 실패했습니다.")
                 }
         }
     }
 
-    sealed class InHouseLoginState {
-        object Init : InHouseLoginState()
-        object Success : InHouseLoginState()
-        data class Failure(val message: String) : InHouseLoginState()
+    sealed class SparkleLoginState {
+        object Init : SparkleLoginState()
+        object Success : SparkleLoginState()
+        data class Failure(val message: String) : SparkleLoginState()
     }
 }

--- a/app/src/main/java/sopt/uni/presentation/login/LoginViewModel.kt
+++ b/app/src/main/java/sopt/uni/presentation/login/LoginViewModel.kt
@@ -39,5 +39,6 @@ class LoginViewModel @Inject constructor(
         object Init : SparkleLoginState()
         object Success : SparkleLoginState()
         data class Failure(val message: String) : SparkleLoginState()
+        object AlreadyCoupled : SparkleLoginState()
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- resolved #119

## 📷 screenshot
<!-- 시연영상을 업로드해주세요. -->

https://github.com/U-is-Ni-in-Korea/Android-United/assets/98825364/4e497d3a-a646-4f2a-a588-98512a0c2cef


## 📝 Work Desciption
<!-- 작업한 내용을 설명해주세요. -->
- coupled id 가 null 이면 닉네임 설정 뷰로
- null 이 아니면, 즉 이미 커플이면 바로 홈 화면 으로 이동

## 📚 Reference 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
- LoginActivity가 좀 어지러운데, 추후에 정리하겠습니다.. 