### PR TITLE
#128 / 홈 조회 시 UE1006에러 대응 

### DIFF
--- a/app/src/main/java/sopt/uni/presentation/common/content/Const.kt
+++ b/app/src/main/java/sopt/uni/presentation/common/content/Const.kt
@@ -3,3 +3,4 @@ package sopt.uni.presentation.common.content
 const val MAX_LENGTH = 5
 const val INVITECODE = "inviteCode"
 const val UNDECIDED = "UNDECIDED"
+const val UE1008 = "UE1008"

--- a/app/src/main/java/sopt/uni/presentation/common/content/Const.kt
+++ b/app/src/main/java/sopt/uni/presentation/common/content/Const.kt
@@ -3,4 +3,5 @@ package sopt.uni.presentation.common.content
 const val MAX_LENGTH = 5
 const val INVITECODE = "inviteCode"
 const val UNDECIDED = "UNDECIDED"
+const val UE1006 = "UE1006"
 const val UE1008 = "UE1008"

--- a/app/src/main/java/sopt/uni/presentation/common/content/ErrorCodeState.kt
+++ b/app/src/main/java/sopt/uni/presentation/common/content/ErrorCodeState.kt
@@ -1,6 +1,7 @@
 package sopt.uni.presentation.common.content
 
 sealed class ErrorCodeState {
+    object NoPartner : ErrorCodeState()
     object NoError : ErrorCodeState()
     object NoToken : ErrorCodeState()
 }

--- a/app/src/main/java/sopt/uni/presentation/home/HomeActivity.kt
+++ b/app/src/main/java/sopt/uni/presentation/home/HomeActivity.kt
@@ -12,6 +12,7 @@ import sopt.uni.databinding.ActivityHomeBinding
 import sopt.uni.presentation.common.content.ErrorCodeState
 import sopt.uni.presentation.common.content.UNDECIDED
 import sopt.uni.presentation.history.HistoryActivity
+import sopt.uni.presentation.invite.NickNameActivity
 import sopt.uni.presentation.login.LoginActivity
 import sopt.uni.presentation.mypage.MypageSettingActivity
 import sopt.uni.presentation.shortgame.createshortgame.CreateShortGameActivity
@@ -132,8 +133,14 @@ class HomeActivity : BindingActivity<ActivityHomeBinding>(R.layout.activity_home
             homeViewModel.errorState.collect {
                 when (it) {
                     is ErrorCodeState.NoToken -> {
-                        showToast("존재하지 않는 사용자입니다. 다시 로그인해주세요")
+                        showToast(getString(R.string.ue1008_error_message))
                         startActivity<LoginActivity>()
+                        Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK
+                    }
+
+                    is ErrorCodeState.NoPartner -> {
+                        showToast(getString(R.string.ue1006_error_message))
+                        startActivity<NickNameActivity>()
                         Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK
                     }
 

--- a/app/src/main/java/sopt/uni/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/sopt/uni/presentation/home/HomeViewModel.kt
@@ -14,6 +14,7 @@ import sopt.uni.data.entity.home.HomeInfo
 import sopt.uni.data.repository.home.HomeRepository
 import sopt.uni.data.repository.shortgame.ShortGameRepository
 import sopt.uni.presentation.common.content.ErrorCodeState
+import sopt.uni.presentation.common.content.UE1006
 import sopt.uni.presentation.common.content.UE1008
 import timber.log.Timber
 import javax.inject.Inject
@@ -57,6 +58,9 @@ class HomeViewModel @Inject constructor(
                 if (errorCode is Exception && errorCode.message.toString() == UE1008) {
                     Timber.e("No Token")
                     _errorState.value = ErrorCodeState.NoToken
+                } else if (errorCode is Exception && errorCode.message.toString() == UE1006) {
+                    Timber.e("No Partner")
+                    _errorState.value = ErrorCodeState.NoPartner
                 }
             }
         }

--- a/app/src/main/java/sopt/uni/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/sopt/uni/presentation/home/HomeViewModel.kt
@@ -14,6 +14,7 @@ import sopt.uni.data.entity.home.HomeInfo
 import sopt.uni.data.repository.home.HomeRepository
 import sopt.uni.data.repository.shortgame.ShortGameRepository
 import sopt.uni.presentation.common.content.ErrorCodeState
+import sopt.uni.presentation.common.content.UE1008
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -53,7 +54,7 @@ class HomeViewModel @Inject constructor(
                 Timber.e("viewmodel's shortGame : ${it.shortGame}")
             }.onFailure { errorCode ->
                 Timber.e("Exception : $errorCode")
-                if (errorCode is Exception && errorCode.message.toString() == "UE1008") {
+                if (errorCode is Exception && errorCode.message.toString() == UE1008) {
                     Timber.e("No Token")
                     _errorState.value = ErrorCodeState.NoToken
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -256,4 +256,8 @@
     <string name="timer_snackbar_message">시간을 설정해주세요</string>
     <string name="timer_number_picker_format">%02d</string>
 
+    <!-- UE Error Message -->
+    <string name="ue1006_error_message">더 이상 기록에 접근할 수 없습니다.</string>
+    <string name="ue1008_error_message">존재하지 않는 사용자입니다. 다시 로그인해주세요</string>
+
 </resources>


### PR DESCRIPTION
## 📌 관련 이슈
- resloved #128 

## 📷 screenshot
<!-- 시연영상을 업로드해주세요. -->

https://github.com/U-is-Ni-in-Korea/Android-United/assets/98825364/54ad6530-a4cf-4fe0-b1cb-ab14cb5365c6


## 📝 Work Desciption
<!-- 작업한 내용을 설명해주세요. -->
- UE1006 에러 상태 추가
- UE1006 발생했을 때, 닉네임 설정 창으로 이동 후 토스트 

## 📚 Reference 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
    가장 에러가 빈번하게 발생할 홈 화면에서만 먼저 대응했습니다. 나머지 API 대응은 추후에 논의해봐요!
