### PR TITLE
[QA] #180 / 커플이 생성되었으나 아직 연결이 안되었을 때 처리 

### DIFF
--- a/app/src/main/java/sopt/uni/data/datasource/local/SparkleStorage.kt
+++ b/app/src/main/java/sopt/uni/data/datasource/local/SparkleStorage.kt
@@ -59,6 +59,10 @@ object SparkleStorage {
         get() = pref.getInt(PARTNER_ID, -1)
         set(value) = pref.edit { putInt(PARTNER_ID, value ?: -1).apply() }
 
+    var coupleId: Int?
+        get() = pref.getInt(COUPLE_ID, -1)
+        set(value) = pref.edit { putInt(COUPLE_ID, value ?: -1).apply() }
+
     var isActive: Boolean
         get() = prefTimer.getBoolean(ACTIVEKEY, false)
         set(value) = prefTimer.edit { putBoolean(ACTIVEKEY, value).apply() }
@@ -93,6 +97,7 @@ const val REFRESH_TOKEN = "refreshToken"
 const val AUTH = "auth"
 const val USER_ID = "userId"
 const val PARTNER_ID = "partnerId"
+const val COUPLE_ID = "coupleId"
 const val NAME = "timer_prefs"
 const val ACTIVEKEY = "isTimerActive"
 const val TOTALTIMEKEY = "totalTime"

--- a/app/src/main/java/sopt/uni/data/datasource/local/SparkleStorage.kt
+++ b/app/src/main/java/sopt/uni/data/datasource/local/SparkleStorage.kt
@@ -63,6 +63,10 @@ object SparkleStorage {
         get() = pref.getInt(COUPLE_ID, -1)
         set(value) = pref.edit { putInt(COUPLE_ID, value ?: -1).apply() }
 
+    var inviteCode: String?
+        get() = pref.getString(INVITE_CODE, EMPTY_TEXT)
+        set(value) = pref.edit { putString(INVITE_CODE, value).apply() }
+
     var isActive: Boolean
         get() = prefTimer.getBoolean(ACTIVEKEY, false)
         set(value) = prefTimer.edit { putBoolean(ACTIVEKEY, value).apply() }
@@ -98,6 +102,7 @@ const val AUTH = "auth"
 const val USER_ID = "userId"
 const val PARTNER_ID = "partnerId"
 const val COUPLE_ID = "coupleId"
+const val INVITE_CODE = "inviteCode"
 const val NAME = "timer_prefs"
 const val ACTIVEKEY = "isTimerActive"
 const val TOTALTIMEKEY = "totalTime"

--- a/app/src/main/java/sopt/uni/data/repository/onboarding/OnBoardingRepository.kt
+++ b/app/src/main/java/sopt/uni/data/repository/onboarding/OnBoardingRepository.kt
@@ -1,12 +1,13 @@
 package sopt.uni.data.repository.onboarding
 
 import retrofit2.Response
+import sopt.uni.data.source.remote.response.ResponseStartDateDto
 
 interface OnBoardingRepository {
 
     suspend fun patchNickName(nickname: String)
 
-    suspend fun postStartDate(startDate: String): String
+    suspend fun postStartDate(startDate: String): Response<ResponseStartDateDto>
 
     suspend fun checkCoupleConnection(): Boolean
 

--- a/app/src/main/java/sopt/uni/data/repository/onboarding/OnBoardingRepositoryImpl.kt
+++ b/app/src/main/java/sopt/uni/data/repository/onboarding/OnBoardingRepositoryImpl.kt
@@ -5,6 +5,7 @@ import sopt.uni.data.service.OnBoardingService
 import sopt.uni.data.source.remote.request.RequestNickNameDto
 import sopt.uni.data.source.remote.request.RequestPostCheckConnectionDto
 import sopt.uni.data.source.remote.request.RequestStartDateDto
+import sopt.uni.data.source.remote.response.ResponseStartDateDto
 import javax.inject.Inject
 
 class OnBoardingRepositoryImpl @Inject constructor(
@@ -15,8 +16,8 @@ class OnBoardingRepositoryImpl @Inject constructor(
         onBoardingService.patchNickName(RequestNickNameDto(nickname))
     }
 
-    override suspend fun postStartDate(startDate: String): String {
-        return onBoardingService.postStartDate(RequestStartDateDto(startDate)).inviteCode
+    override suspend fun postStartDate(startDate: String): Response<ResponseStartDateDto> {
+        return onBoardingService.postStartDate(RequestStartDateDto(startDate))
     }
 
     override suspend fun checkCoupleConnection(): Boolean {

--- a/app/src/main/java/sopt/uni/data/service/OnBoardingService.kt
+++ b/app/src/main/java/sopt/uni/data/service/OnBoardingService.kt
@@ -22,7 +22,7 @@ interface OnBoardingService {
     @POST("api/couple")
     suspend fun postStartDate(
         @Body request: RequestStartDateDto,
-    ): ResponseStartDateDto
+    ): Response<ResponseStartDateDto>
 
     @GET("api/couple/join")
     suspend fun checkConnection(): ResponseCheckConnectionDto

--- a/app/src/main/java/sopt/uni/data/source/remote/response/ResponseStartDateDto.kt
+++ b/app/src/main/java/sopt/uni/data/source/remote/response/ResponseStartDateDto.kt
@@ -8,7 +8,7 @@ data class ResponseStartDateDto(
     @SerialName("heartToken")
     val heartToken: Int,
     @SerialName("id")
-    val id: Int,
+    val coupleId: Int,
     @SerialName("inviteCode")
     val inviteCode: String,
     @SerialName("startDate")

--- a/app/src/main/java/sopt/uni/presentation/IntroActivity.kt
+++ b/app/src/main/java/sopt/uni/presentation/IntroActivity.kt
@@ -10,6 +10,7 @@ import sopt.uni.data.datasource.local.SparkleStorage
 import sopt.uni.data.repository.shortgame.ShortGameRepository
 import sopt.uni.presentation.home.HomeActivity
 import sopt.uni.presentation.invite.NickNameActivity
+import sopt.uni.presentation.invite.ShareInviteCodeActivity
 import sopt.uni.presentation.onboarding.OnBoardingActivity
 import sopt.uni.util.extension.startActivity
 import javax.inject.Inject
@@ -32,8 +33,11 @@ class IntroActivity : AppCompatActivity() {
         if (SparkleStorage.accessToken != null) {
             Log.e("accessToken", SparkleStorage.accessToken.toString())
             Log.e("partnerId", SparkleStorage.partnerId.toString())
-            if (SparkleStorage.partnerId != -1) {
+            if (SparkleStorage.partnerId != -1 && SparkleStorage.coupleId != -1) {
                 startActivity<HomeActivity>()
+                Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK
+            } else if (SparkleStorage.partnerId == -1 && SparkleStorage.coupleId != -1) {
+                startActivity<ShareInviteCodeActivity>()
                 Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK
             } else {
                 startActivity<NickNameActivity>()

--- a/app/src/main/java/sopt/uni/presentation/invite/DdayActivity.kt
+++ b/app/src/main/java/sopt/uni/presentation/invite/DdayActivity.kt
@@ -2,6 +2,7 @@ package sopt.uni.presentation.invite
 
 import android.content.Intent
 import android.os.Bundle
+import androidx.activity.OnBackPressedCallback
 import androidx.activity.viewModels
 import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
@@ -12,6 +13,7 @@ import sopt.uni.presentation.common.content.INVITECODE
 import sopt.uni.util.DateUtil
 import sopt.uni.util.binding.BindingActivity
 import sopt.uni.util.extension.setOnSingleClickListener
+import sopt.uni.util.extension.startActivity
 import java.util.Calendar
 
 @AndroidEntryPoint
@@ -24,6 +26,7 @@ class DdayActivity : BindingActivity<ActivityDDayBinding>(R.layout.activity_d_da
         setMaxDate()
         moveToShareInviteCode()
         moveToPrevPage()
+        initOnBackPressedListener()
     }
 
     private fun moveToShareInviteCode() {
@@ -48,12 +51,27 @@ class DdayActivity : BindingActivity<ActivityDDayBinding>(R.layout.activity_d_da
 
     private fun moveToPrevPage() {
         binding.ivBackArrow.setOnSingleClickListener {
-            finish()
+            backToInviteHub()
         }
     }
 
     private fun setMaxDate() {
         val calendar = Calendar.getInstance()
         binding.dpDDay.maxDate = calendar.timeInMillis
+    }
+
+    private fun initOnBackPressedListener() {
+        val onBackPressedCallback = object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                backToInviteHub()
+            }
+        }
+        this.onBackPressedDispatcher.addCallback(this, onBackPressedCallback)
+    }
+
+    private fun backToInviteHub() {
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK)
+        startActivity<InviteHubActivity>()
+        finish()
     }
 }

--- a/app/src/main/java/sopt/uni/presentation/invite/DdayViewModel.kt
+++ b/app/src/main/java/sopt/uni/presentation/invite/DdayViewModel.kt
@@ -6,6 +6,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import sopt.uni.data.datasource.local.SparkleStorage
 import sopt.uni.data.repository.onboarding.OnBoardingRepository
 import timber.log.Timber
 import javax.inject.Inject
@@ -26,6 +27,7 @@ class DdayViewModel @Inject constructor(
                 it.body()?.let { response ->
                     Timber.d("기념일 갱신이 성공했습니다.")
                     _inviteCode.value = response.inviteCode
+                    SparkleStorage.coupleId = response.coupleId
                 } ?: run {
                     Timber.d("기념일 갱신에서 null이 반환되었습니다.")
                 }

--- a/app/src/main/java/sopt/uni/presentation/invite/DdayViewModel.kt
+++ b/app/src/main/java/sopt/uni/presentation/invite/DdayViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import sopt.uni.data.repository.onboarding.OnBoardingRepository
 import timber.log.Timber
@@ -14,14 +15,15 @@ class DdayViewModel @Inject constructor(
     private val onBoardingRepository: OnBoardingRepository,
 ) : ViewModel() {
 
-    var inviteCode = MutableStateFlow("")
+    private val _inviteCode = MutableStateFlow<String>("")
+    val inviteCode get() = _inviteCode.asStateFlow()
 
     fun postStartDate(startDate: String) {
         viewModelScope.launch {
             kotlin.runCatching {
                 onBoardingRepository.postStartDate(startDate = startDate)
             }.fold({
-                inviteCode.emit(it)
+                _inviteCode.emit(it)
                 Timber.d("기념일 갱신이 완료되었습니다.")
             }, {
                 Timber.d("기념일 갱신이 실패했습니다.")

--- a/app/src/main/java/sopt/uni/presentation/invite/DdayViewModel.kt
+++ b/app/src/main/java/sopt/uni/presentation/invite/DdayViewModel.kt
@@ -23,8 +23,12 @@ class DdayViewModel @Inject constructor(
             kotlin.runCatching {
                 onBoardingRepository.postStartDate(startDate = startDate)
             }.fold({
-                _inviteCode.emit(it)
-                Timber.d("기념일 갱신이 완료되었습니다.")
+                it.body()?.let { response ->
+                    Timber.d("기념일 갱신이 성공했습니다.")
+                    _inviteCode.value = response.inviteCode
+                } ?: run {
+                    Timber.d("기념일 갱신에서 null이 반환되었습니다.")
+                }
             }, {
                 Timber.d("기념일 갱신이 실패했습니다.")
             })

--- a/app/src/main/java/sopt/uni/presentation/invite/DdayViewModel.kt
+++ b/app/src/main/java/sopt/uni/presentation/invite/DdayViewModel.kt
@@ -27,6 +27,7 @@ class DdayViewModel @Inject constructor(
                 it.body()?.let { response ->
                     Timber.d("기념일 갱신이 성공했습니다.")
                     _inviteCode.value = response.inviteCode
+                    SparkleStorage.inviteCode = response.inviteCode
                     SparkleStorage.coupleId = response.coupleId
                 } ?: run {
                     Timber.d("기념일 갱신에서 null이 반환되었습니다.")

--- a/app/src/main/java/sopt/uni/presentation/invite/InviteHubActivity.kt
+++ b/app/src/main/java/sopt/uni/presentation/invite/InviteHubActivity.kt
@@ -1,6 +1,8 @@
 package sopt.uni.presentation.invite
 
+import android.content.Intent
 import android.os.Bundle
+import androidx.activity.OnBackPressedCallback
 import dagger.hilt.android.AndroidEntryPoint
 import sopt.uni.R
 import sopt.uni.databinding.ActivityInviteHubBinding
@@ -17,6 +19,7 @@ class InviteHubActivity : BindingActivity<ActivityInviteHubBinding>(R.layout.act
         moveToEnterDday()
         moveToEnterInviteCode()
         moveToPrevPage()
+        initOnBackPressedListener()
     }
 
     private fun moveToEnterDday() {
@@ -33,7 +36,22 @@ class InviteHubActivity : BindingActivity<ActivityInviteHubBinding>(R.layout.act
 
     private fun moveToPrevPage() {
         binding.ivBackArrow.setOnSingleClickListener {
-            finish()
+            backToNickNameActivity()
         }
+    }
+
+    private fun initOnBackPressedListener() {
+        val onBackPressedCallback = object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                backToNickNameActivity()
+            }
+        }
+        this.onBackPressedDispatcher.addCallback(this, onBackPressedCallback)
+    }
+
+    private fun backToNickNameActivity() {
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK)
+        startActivity<NickNameActivity>()
+        finish()
     }
 }

--- a/app/src/main/java/sopt/uni/presentation/invite/NickNameActivity.kt
+++ b/app/src/main/java/sopt/uni/presentation/invite/NickNameActivity.kt
@@ -1,16 +1,19 @@
 package sopt.uni.presentation.invite
 
 import android.content.Context
+import android.content.Intent
 import android.graphics.Rect
 import android.os.Bundle
 import android.view.MotionEvent
 import android.view.MotionEvent.ACTION_DOWN
 import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
+import androidx.activity.OnBackPressedCallback
 import androidx.activity.viewModels
 import dagger.hilt.android.AndroidEntryPoint
 import sopt.uni.R
 import sopt.uni.databinding.ActivityNicknameBinding
+import sopt.uni.presentation.login.LoginActivity
 import sopt.uni.presentation.mypage.MypageAccountLogoutDialogFragment
 import sopt.uni.util.binding.BindingActivity
 import sopt.uni.util.extension.setOnSingleClickListener
@@ -28,6 +31,7 @@ class NickNameActivity : BindingActivity<ActivityNicknameBinding>(R.layout.activ
         moveToPrevPage()
         moveToAskPage()
         logoutOnNickNamePage()
+        initOnBackPressedListener()
     }
 
     private fun moveToInviteHub() {
@@ -39,7 +43,7 @@ class NickNameActivity : BindingActivity<ActivityNicknameBinding>(R.layout.activ
 
     private fun moveToPrevPage() {
         binding.ivBackArrow.setOnSingleClickListener {
-            finish()
+            backToLogin()
         }
     }
 
@@ -73,5 +77,20 @@ class NickNameActivity : BindingActivity<ActivityNicknameBinding>(R.layout.activ
                 "MypageAccountLogoutDialogFragment",
             )
         }
+    }
+
+    private fun initOnBackPressedListener() {
+        val onBackPressedCallback = object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                backToLogin()
+            }
+        }
+        this.onBackPressedDispatcher.addCallback(this, onBackPressedCallback)
+    }
+
+    private fun backToLogin() {
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK)
+        startActivity<LoginActivity>()
+        finish()
     }
 }

--- a/app/src/main/java/sopt/uni/presentation/invite/ShareInviteCodeActivity.kt
+++ b/app/src/main/java/sopt/uni/presentation/invite/ShareInviteCodeActivity.kt
@@ -9,15 +9,14 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import sopt.uni.R
+import sopt.uni.data.datasource.local.SparkleStorage
 import sopt.uni.databinding.ActivityShareInviteCodeBinding
-import sopt.uni.presentation.common.content.INVITECODE
 import sopt.uni.presentation.home.HomeActivity
 import sopt.uni.util.UiState
 import sopt.uni.util.binding.BindingActivity
 import sopt.uni.util.extension.setOnSingleClickListener
 import sopt.uni.util.extension.showToast
 import sopt.uni.util.extension.startActivity
-import timber.log.Timber
 
 @AndroidEntryPoint
 class ShareInviteCodeActivity :
@@ -34,8 +33,7 @@ class ShareInviteCodeActivity :
     }
 
     private fun getInviteCode() {
-        Timber.e(intent.getStringExtra(INVITECODE))
-        binding.tvInviteCode.text = intent.getStringExtra(INVITECODE)
+        binding.tvInviteCode.text = SparkleStorage.inviteCode
     }
 
     private fun moveToPrevPage() {

--- a/app/src/main/java/sopt/uni/presentation/invite/ShareInviteCodeActivity.kt
+++ b/app/src/main/java/sopt/uni/presentation/invite/ShareInviteCodeActivity.kt
@@ -2,6 +2,7 @@ package sopt.uni.presentation.invite
 
 import android.content.Intent
 import android.os.Bundle
+import androidx.activity.OnBackPressedCallback
 import androidx.activity.viewModels
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
@@ -30,6 +31,7 @@ class ShareInviteCodeActivity :
         getInviteCode()
         checkCoupleConnection()
         copyInviteCode()
+        initOnBackPressedListener()
     }
 
     private fun getInviteCode() {
@@ -38,7 +40,7 @@ class ShareInviteCodeActivity :
 
     private fun moveToPrevPage() {
         binding.ivBackArrow.setOnSingleClickListener {
-            finish()
+            backToDdayActivity()
         }
     }
 
@@ -78,5 +80,20 @@ class ShareInviteCodeActivity :
             val shareIntent = Intent.createChooser(sendIntent, null)
             startActivity(shareIntent)
         }
+    }
+
+    private fun initOnBackPressedListener() {
+        val onBackPressedCallback = object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                backToDdayActivity()
+            }
+        }
+        this.onBackPressedDispatcher.addCallback(this, onBackPressedCallback)
+    }
+
+    private fun backToDdayActivity() {
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK)
+        startActivity<DdayActivity>()
+        finish()
     }
 }

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -283,6 +283,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="2dp"
+                android:visibility="invisible"
                 android:background="@drawable/bg_heart_btn"
                 android:elevation="2dp"
                 android:paddingHorizontal="12dp"


### PR DESCRIPTION
## 📌 관련 이슈
- #171 
- resloved #180 

## 📷 screenshot
<!-- 시연영상을 업로드해주세요. -->

https://github.com/U-is-Ni-in-Korea/Android-United/assets/98825364/6763b510-eef5-4b0a-887c-cac420c2f0be


## 📝 Work Desciption
<!-- 작업한 내용을 설명해주세요. -->
- 171번 이슈 하트 다이얼로그 레이아웃 삭제했습니다.
- inviteCode와 coupleId를 로컬 값에 저장하여 재접속 시 분기처리했습니다.
- 재접속 시 NickNameActivity나 ShareInviteCodeActivity가 띄어졌을 시 기존 뒤로가기 로직을 수행화면 화면 위에 빈 화면이 띄어지기 때문에 뒤로가기 로직을 수정했습니다. 

## 📚 Reference 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
    뒤로가기 로직 개선사항이 있다면 알려주세요!